### PR TITLE
fixes and improvements

### DIFF
--- a/recipes-dom0/dom0-image-weston/files/meta-xt-prod-extra/recipes-graphics/images/core-image-weston.bbappend
+++ b/recipes-dom0/dom0-image-weston/files/meta-xt-prod-extra/recipes-graphics/images/core-image-weston.bbappend
@@ -4,6 +4,7 @@ IMAGE_INSTALL_append = " \
     domu-dtb \
     libxenbe \
     displbe \
+    kmscube \
 "
 
 populate_append() {

--- a/recipes-dom0/dom0-image-weston/files/meta-xt-prod-extra/recipes-graphics/images/dom0-image-weston-domu-copy-kernel.bb
+++ b/recipes-dom0/dom0-image-weston/files/meta-xt-prod-extra/recipes-graphics/images/dom0-image-weston-domu-copy-kernel.bb
@@ -3,6 +3,12 @@ LICENSE = "CLOSED"
 IMAGES_DIR="boot/domu"
 FILES_${PN} += "${base_prefix}/${IMAGES_DIR}"
 
+# FIXME: if not forced and sstate cache is used then an old version of
+# this package (read old DomU kernel images) can be used from cache
+# regardless of the fact that binaries may have actually changed, e.g.
+# the recipe code is not changed, there is no SRC_URI with checksum
+# force install so if DomU kernel changes we use the latest binaries
+do_install[nostamp] = "1"
 do_install() {
    install -d "${D}/${base_prefix}/${IMAGES_DIR}"
    cp -rf "${XT_SHARED_ROOTFS_DIR}/${IMAGES_DIR}" "${D}/${base_prefix}/boot"

--- a/recipes-domu/domu-image-weston/files/meta-xt-prod-extra/recipes-graphics/gles-module/files/72-pvr-seat.rules.patch
+++ b/recipes-domu/domu-image-weston/files/meta-xt-prod-extra/recipes-graphics/gles-module/files/72-pvr-seat.rules.patch
@@ -1,0 +1,8 @@
+--- a/etc/udev/rules.d/72-pvr-seat.rules	2017-04-24 10:03:49.000000000 +0300
++++ b/etc/udev/rules.d/72-pvr-seat.rules	2017-06-08 14:26:07.947974081 +0300
+@@ -4,4 +4,4 @@
+ # License Strictly Confidential.
+ #### ###########################################################################
+ # Rules for PowerVR device nodes
+-SUBSYSTEM=="drm", DEVPATH=="/devices/platform/soc/fd000000.gsx/drm/*", TAG+="seat", TAG+="master-of-seat", ENV{ID_AUTOSEAT}="1", ENV{ID_SEAT}="seat1"
++SUBSYSTEM=="drm", DEVPATH=="/devices/platform/passthrough/fd000000.gsx/drm/*", TAG+="seat", TAG+="master-of-seat", ENV{ID_AUTOSEAT}="1", ENV{ID_SEAT}="seat1"

--- a/recipes-domu/domu-image-weston/files/meta-xt-prod-extra/recipes-graphics/gles-module/gles-user-module.bbappend
+++ b/recipes-domu/domu-image-weston/files/meta-xt-prod-extra/recipes-graphics/gles-module/gles-user-module.bbappend
@@ -1,0 +1,6 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI_append = " \
+    file://72-pvr-seat.rules.patch \
+"
+

--- a/recipes-domu/domu-image-weston/files/meta-xt-prod-extra/recipes-graphics/images/core-image-weston.bbappend
+++ b/recipes-domu/domu-image-weston/files/meta-xt-prod-extra/recipes-graphics/images/core-image-weston.bbappend
@@ -1,0 +1,3 @@
+IMAGE_INSTALL_append = " \
+    kmscube \
+"

--- a/recipes-domu/domu-image-weston/files/meta-xt-prod-extra/recipes-kernel/kernel-module-gles/kernel-module-gles.bbappend
+++ b/recipes-domu/domu-image-weston/files/meta-xt-prod-extra/recipes-kernel/kernel-module-gles/kernel-module-gles.bbappend
@@ -1,0 +1,13 @@
+PVRKM_URL = "git://github.com/xen-troops/pvr_km.git"
+BRANCH = "vgpu-dev"
+SRCREV = "${AUTOREV}"
+
+SRC_URI_r8a7795 = "${PVRKM_URL};protocol=http;branch=${BRANCH}"
+SRC_URI_r8a7796 = "${PVRKM_URL};protocol=http;branch=${BRANCH}"
+
+S = "${WORKDIR}/git"
+
+BUILD = "release"
+KBUILD_OUTDIR_r8a7795 = "binary_r8a7795_linux_${BUILD}/target_aarch64/kbuild/"
+KBUILD_OUTDIR_r8a7796 = "binary_r8a7796_linux_${BUILD}/target_aarch64/kbuild/"
+


### PR DESCRIPTION
Fixes:
- build pvr kernel module from Xen-troops sources, not from default uri
- force DomU kernel to be always installed
- fix udev rule for DomU's pvr km: weston seat
Added:
- kmscube