### PR TITLE
Fix: really use DomU kernel

### DIFF
--- a/recipes-dom0/dom0-image-weston/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domu.cfg
+++ b/recipes-dom0/dom0-image-weston/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domu.cfg
@@ -13,7 +13,7 @@ seclabel='system_u:system_r:domU_t'
 name = "DomU"
 
 # Kernel image to boot
-kernel = "/boot/Image"
+kernel = "/boot/domu/Image"
 
 device_tree = "/xen/domu.dtb"
 


### PR DESCRIPTION
Instead of using DomU kernel from /boot/domu Dom0's
kernel was used to boot DomU from /boot.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>