### PR TITLE
IPMMU optimization that is mandatory for IOMMU+COPROC integration

### DIFF
--- a/recipes-dom0/dom0-image-weston/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domu.cfg
+++ b/recipes-dom0/dom0-image-weston/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domu.cfg
@@ -17,7 +17,7 @@ kernel = "/boot/domu/Image"
 
 device_tree = "/xen/domu.dtb"
 
-dtdev=[ "/soc/gsx@fd000000", "/soc/gsx1@fd000000", "/soc/gsx2@fd000000", "/soc/gsx3@fd000000" ]
+dtdev=[ "/soc/gsx@fd000000" ]
 irqs=[ 151 ]
 iomem=[ "0xfd000,40" ]
 

--- a/recipes-dom0/dom0-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas/r8a7795-salvator-x-dom0.dts
+++ b/recipes-dom0/dom0-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas/r8a7795-salvator-x-dom0.dts
@@ -62,21 +62,6 @@
 		};
 	};
 
-	soc {
-		/* keep dummy gsx nodes while we can handle only one ipmmu per device */
-		gsx1: gsx1@fd000000 {
-			reg = <0 0xfd000000 0 0x3ffff>;
-		};
-
-		gsx2: gsx2@fd000000 {
-			reg = <0 0xfd000000 0 0x3ffff>;
-		};
-
-		gsx3: gsx3@fd000000 {
-			reg = <0 0xfd000000 0 0x3ffff>;
-		};
-	};
-
 	memory@48000000 {
 		device_type = "memory";
 		/* first 128MB is reserved for secure area. */
@@ -1119,29 +1104,16 @@
 	iommus = <&ipmmu_pv0 0>, <&ipmmu_pv0 1>,
 			 <&ipmmu_pv0 2>, <&ipmmu_pv0 3>,
 			 <&ipmmu_pv0 4>, <&ipmmu_pv0 5>,
-			 <&ipmmu_pv0 6>, <&ipmmu_pv0 7>;
-};
-
-/* keep dummy gsx nodes while we can handle only one ipmmu per device */
-&gsx1 {
-	xen,passthrough;
-	iommus = <&ipmmu_pv1 0>, <&ipmmu_pv1 1>,
+			 <&ipmmu_pv0 6>, <&ipmmu_pv0 7>,
+			 <&ipmmu_pv1 0>, <&ipmmu_pv1 1>,
 			 <&ipmmu_pv1 2>, <&ipmmu_pv1 3>,
 			 <&ipmmu_pv1 4>, <&ipmmu_pv1 5>,
-			 <&ipmmu_pv1 6>, <&ipmmu_pv1 7>;
-};
-
-&gsx2 {
-	xen,passthrough;
-	iommus = <&ipmmu_pv2 0>, <&ipmmu_pv2 1>,
+			 <&ipmmu_pv1 6>, <&ipmmu_pv1 7>,
+			 <&ipmmu_pv2 0>, <&ipmmu_pv2 1>,
 			 <&ipmmu_pv2 2>, <&ipmmu_pv2 3>,
 			 <&ipmmu_pv2 4>, <&ipmmu_pv2 5>,
-			 <&ipmmu_pv2 6>, <&ipmmu_pv2 7>;
-};
-
-&gsx3 {
-	xen,passthrough;
-	iommus = <&ipmmu_pv3 0>, <&ipmmu_pv3 1>,
+			 <&ipmmu_pv2 6>, <&ipmmu_pv2 7>,
+			 <&ipmmu_pv3 0>, <&ipmmu_pv3 1>,
 			 <&ipmmu_pv3 2>, <&ipmmu_pv3 3>,
 			 <&ipmmu_pv3 4>, <&ipmmu_pv3 5>,
 			 <&ipmmu_pv3 6>, <&ipmmu_pv3 7>;


### PR DESCRIPTION
There is no need to keep dummy gsx nodes as we already have
required support in the IPMMU driver for handling master devices
that are tied to multiple cache IPMMUs.

This request is related to
xen-troops/xen#72