### PR TITLE
Fix absolute paths for Xen symlinks

### DIFF
--- a/recipes-dom0/dom0-image-weston/files/meta-xt-prod-extra/recipes-extended/xen/xen_git.bbappend
+++ b/recipes-dom0/dom0-image-weston/files/meta-xt-prod-extra/recipes-extended/xen/xen_git.bbappend
@@ -12,10 +12,10 @@ FLASK_POLICY_FILE_rcar = "xenpolicy-4.9-rc"
 do_deploy_append_rcar () {
     if [ -f ${D}/boot/xen ]; then
         uboot-mkimage -A arm64 -C none -T kernel -a 0x78080000 -e 0x78080000 -n "XEN" -d ${D}/boot/xen ${DEPLOYDIR}/xen-${MACHINE}.uImage
-        ln -sf ${DEPLOYDIR}/xen-${MACHINE}.uImage ${DEPLOYDIR}/xen-uImage
+        ln -sfr ${DEPLOYDIR}/xen-${MACHINE}.uImage ${DEPLOYDIR}/xen-uImage
     fi
 
     if [ -f ${D}/boot/${FLASK_POLICY_FILE} ]; then
-        ln -sf ${DEPLOYDIR}/${FLASK_POLICY_FILE} ${DEPLOYDIR}/xenpolicy
+        ln -sfr ${DEPLOYDIR}/${FLASK_POLICY_FILE} ${DEPLOYDIR}/xenpolicy
     fi
 }


### PR DESCRIPTION
During Xen deployment symlinks are created with absolute path
instead of relative for xen-uImage and xenpolicy.

Signed-off-by: Iurii Artemenko <iurii_artemenko@epam.com>