### PR TITLE
Odd layers for DomU build.

### DIFF
--- a/recipes-dom0/dom0-image-weston/dom0-image-weston.bbappend
+++ b/recipes-dom0/dom0-image-weston/dom0-image-weston.bbappend
@@ -13,9 +13,9 @@ do_fetch[depends] += "domu-image-weston:do_${BB_DEFAULT_TASK}"
 ################################################################################
 # Renesas R-Car
 ################################################################################
-SRC_URI_rcar = "repo://github.com/xen-troops/manifests;protocol=https;branch=vgpu-dev;scmdata=keep"
+SRC_URI_rcar = "repo://github.com/xen-troops/manifests;protocol=https;branch=master;manifest=prod_devel/dom0.xml;scmdata=keep"
 XT_QUIRK_PATCH_SRC_URI_rcar = "file://${S}/meta-renesas/meta-rcar-gen3/docs/sample/patch/patch-for-linaro-gcc/0001-rcar-gen3-add-readme-for-building-with-Linaro-Gcc.patch;patchdir=meta-renesas"
-XT_BB_LAYERS_FILE_rcar = "meta-rcar-gen3/doc/bblayers.conf"
+XT_BB_LAYERS_FILE_rcar = "meta-xt-prod-extra/conf/bblayers.conf.sample"
 XT_BB_LOCAL_CONF_FILE_rcar = "meta-rcar-gen3/doc/local-wayland.conf"
 
 python do_unpack_append_rcar() {

--- a/recipes-dom0/dom0-image-weston/files/meta-xt-prod-extra/conf/bblayers.conf.sample
+++ b/recipes-dom0/dom0-image-weston/files/meta-xt-prod-extra/conf/bblayers.conf.sample
@@ -1,0 +1,23 @@
+# LAYER_CONF_VERSION is increased each time build/conf/bblayers.conf
+# changes incompatibly
+LCONF_VERSION = "6"
+
+BBPATH = "${TOPDIR}"
+BBFILES ?= ""
+
+BBLAYERS ?= " \
+  ${TOPDIR}/../poky/meta \
+  ${TOPDIR}/../poky/meta-poky \
+  ${TOPDIR}/../poky/meta-yocto-bsp \
+  ${TOPDIR}/../meta-renesas/meta-rcar-gen3 \
+  ${TOPDIR}/../meta-linaro/meta-linaro-toolchain \
+  ${TOPDIR}/../meta-openembedded/meta-oe \
+  ${TOPDIR}/../meta-openembedded/meta-networking \
+  ${TOPDIR}/../meta-openembedded/meta-python \
+  ${TOPDIR}/../meta-selinux \
+  ${TOPDIR}/../meta-virtualization \
+  "
+BBLAYERS_NON_REMOVABLE ?= " \
+  ${TOPDIR}/../poky/meta \
+  ${TOPDIR}/../poky/meta-poky \
+  "

--- a/recipes-domu/domu-image-weston/domu-image-weston.bbappend
+++ b/recipes-domu/domu-image-weston/domu-image-weston.bbappend
@@ -11,9 +11,9 @@ XT_QUIRK_BB_ADD_LAYER += "meta-xt-prod-extra"
 ################################################################################
 # Renesas R-Car
 ################################################################################
-SRC_URI_rcar = "repo://github.com/xen-troops/manifests;protocol=https;branch=vgpu-dev;scmdata=keep"
+SRC_URI_rcar = "repo://github.com/xen-troops/manifests;protocol=https;branch=master;manifest=prod_devel/domu.xml;scmdata=keep"
 XT_QUIRK_PATCH_SRC_URI_rcar = "file://${S}/meta-renesas/meta-rcar-gen3/docs/sample/patch/patch-for-linaro-gcc/0001-rcar-gen3-add-readme-for-building-with-Linaro-Gcc.patch;patchdir=meta-renesas"
-XT_BB_LAYERS_FILE_rcar = "meta-rcar-gen3/doc/bblayers.conf"
+XT_BB_LAYERS_FILE_rcar = "meta-xt-prod-extra/conf/bblayers.conf.sample"
 XT_BB_LOCAL_CONF_FILE_rcar = "meta-rcar-gen3/doc/local-wayland.conf"
 
 python do_unpack_append_rcar() {

--- a/recipes-domu/domu-image-weston/files/meta-xt-prod-extra/conf/bblayers.conf.sample
+++ b/recipes-domu/domu-image-weston/files/meta-xt-prod-extra/conf/bblayers.conf.sample
@@ -1,0 +1,21 @@
+# LAYER_CONF_VERSION is increased each time build/conf/bblayers.conf
+# changes incompatibly
+LCONF_VERSION = "6"
+
+BBPATH = "${TOPDIR}"
+BBFILES ?= ""
+
+BBLAYERS ?= " \
+  ${TOPDIR}/../poky/meta \
+  ${TOPDIR}/../poky/meta-poky \
+  ${TOPDIR}/../poky/meta-yocto-bsp \
+  ${TOPDIR}/../meta-renesas/meta-rcar-gen3 \
+  ${TOPDIR}/../meta-linaro/meta-linaro-toolchain \
+  ${TOPDIR}/../meta-openembedded/meta-oe \
+  ${TOPDIR}/../meta-openembedded/meta-networking \
+  ${TOPDIR}/../meta-openembedded/meta-python \
+  "
+BBLAYERS_NON_REMOVABLE ?= " \
+  ${TOPDIR}/../poky/meta \
+  ${TOPDIR}/../poky/meta-poky \
+  "


### PR DESCRIPTION
Make "dom0" and "domU" use separate manifest files.
Exclude "meta-virtualization" and "meta-selinux" layers
from "domU" image build.

Signed-off-by: Iurii Artemenko <iurii_artemenko@epam.com>