### PR TITLE
Add domu config for NFS no coproc

### DIFF
--- a/recipes-dom0/dom0-image-weston/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domu-nfs-no-coproc.cfg
+++ b/recipes-dom0/dom0-image-weston/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domu-nfs-no-coproc.cfg
@@ -1,0 +1,34 @@
+# =====================================================================
+# Example PV Linux guest configuration
+# =====================================================================
+#
+# This is a fairly minimal example of what is required for a
+# Paravirtualised Linux guest. For a more complete guide see xl.cfg(5)
+
+seclabel='system_u:system_r:domU_t'
+
+# Guest name
+name = "DomU"
+
+# Kernel image to boot
+kernel = "/boot/domu/Image"
+
+device_tree = "/xen/domu.dtb"
+
+# Kernel command line options
+extra = "root=/dev/nfs nfsroot=192.168.1.100:/srv/domu ip=192.168.1.11 rw rootwait console=hvc0 cma=64M"
+
+# Initial memory allocation (MB)
+memory = 256
+
+# Number of VCPUS
+vcpus = 4
+
+# Network devices
+# A list of 'vifspec' entries as described in
+# docs/misc/xl-network-configuration.markdown
+vif = [ 'bridge=xenbr0,mac=08:00:27:ff:cb:cd' ]
+
+vdispl = [ 'backend=0, beAlloc=0, connectors=id0:640x480' ]
+
+on_crash = 'preserve'


### PR DESCRIPTION
This configuration file is about to be used for
NFS root without coproc enabled.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>