### PR TITLE
dom0.dts/domd.dts: Remove "power-domains" property from SDHI2 node

### DIFF
--- a/recipes-domd/agl/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas/r8a7795-salvator-x-dom0.dts
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas/r8a7795-salvator-x-dom0.dts
@@ -859,13 +859,6 @@
 	status = "okay";
 
 	iommus = <&ipmmu_ds1 34>;
-
-	/*
-	   FIXME: following is a hacky way to get A3VP power domain enabled from
-	  DomD. SDHI2 is choosen because onboard eMMC is going to be turned on
-	  always and overriding its native ALWAYS_ON power domain is not harmful
-	 */
-	power-domains = <&sysc R8A7795_PD_A3VP>;
 };
 
 &sdhi3 {

--- a/recipes-domd/agl/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas/r8a7795-salvator-x-domd.dts
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas/r8a7795-salvator-x-domd.dts
@@ -768,7 +768,6 @@
 	drive-strength = <1>;
 	non-removable;
 	status = "okay";
-	power-domains = <&sysc R8A7795_PD_A3VP>;
 };
 
 &sdhi3 {

--- a/recipes-domd/agl/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas/r8a7796-salvator-x-dom0.dts
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas/r8a7796-salvator-x-dom0.dts
@@ -634,13 +634,6 @@
 	status = "okay";
 
 	iommus = <&ipmmu_ds1 34>;
-
-	/*
-	   FIXME: following is a hacky way to get A3VP power domain enabled from
-	  DomD. SDHI2 is choosen because onboard eMMC is going to be turned on
-	  always and overriding its native ALWAYS_ON power domain is not harmful
-	 */
-	power-domains = <&sysc R8A7796_PD_A3VC>;
 };
 
 &sdhi3 {

--- a/recipes-domd/agl/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas/r8a7796-salvator-x-domd.dts
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas/r8a7796-salvator-x-domd.dts
@@ -552,7 +552,6 @@
 	mmc-hs400-1_8v;
 	bus-width = <8>;
 	non-removable;
-	power-domains = <&sysc R8A7796_PD_A3VC>;
 	status = "okay";
 };
 


### PR DESCRIPTION
This hint is not needed anymore. With corresponding support in Xen
the A3VP power domain as well as other non ALWAYS_ON domains
some IPMMU caches belong to are turned on in advance.

Signed-off-by: Oleksandr Tyshchenko <oleksandr_tyshchenko@epam.com>
Reviewed-by: Andrii Anisov <andrii_anisov@epam.com>