### PR TITLE
dom0: fix passing XT_GUESTS_INSTALL into lower yocto build

### DIFF
--- a/recipes-dom0/dom0-image-thin-initramfs/dom0-image-thin-initramfs.bbappend
+++ b/recipes-dom0/dom0-image-thin-initramfs/dom0-image-thin-initramfs.bbappend
@@ -52,7 +52,7 @@ add_to_local_conf() {
 
     base_update_conf_value ${local_conf} PREFERRED_VERSION_xen "4.10.0+git\%"
 
-    base_update_conf_value ${local_conf} XT_GUESTS_INSTALL ${XT_GUESTS_INSTALL}
+    base_update_conf_value ${local_conf} XT_GUESTS_INSTALL "${XT_GUESTS_INSTALL}"
 }
 
 python do_configure_append() {


### PR DESCRIPTION
Unfortunately a missprint sneaked into the previous patch, so it should be fixed to get it functional.