### PR TITLE
domd: weston seats harcode clenup

### DIFF
--- a/recipes-domd/agl/files/meta-xt-prod-extra/recipes-graphics/wayland/weston/weston-seats.rules
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/recipes-graphics/wayland/weston/weston-seats.rules
@@ -1,2 +1,2 @@
-ENV{ID_VENDOR_ID}=="1fd2", ENV{ID_MODEL_ID}=="6103", DEVPATH=="/devices/platform/soc/ee0a0100.usb/usb1/*", ENV{WL_OUTPUT}="HDMI-A-1"
-ENV{ID_VENDOR_ID}=="1fd2", ENV{ID_MODEL_ID}=="6103", DEVPATH=="/devices/platform/soc/ee0c0100.usb/usb2/*", ENV{WL_OUTPUT}="HDMI-A-2"
+DEVPATH=="/devices/platform/soc/ee0a0100.usb/usb*/*", ENV{WL_OUTPUT}="HDMI-A-1"
+DEVPATH=="/devices/platform/soc/ee0c0100.usb/usb*/*", ENV{WL_OUTPUT}="HDMI-A-2"


### PR DESCRIPTION
Remove vendor and device ID hardcode from weston seats rules, also
add more wildcards to USB device pathes in order to get the setup
portable to a different setup configuration.

Signed-off-by: Andrii Anisov <andrii_anisov@epam.com>