### PR TITLE
Speedup build by rearranging build dependencies

### DIFF
--- a/recipes-dom0/dom0-image-rescue-initramfs/dom0-image-rescue-initramfs.bbappend
+++ b/recipes-dom0/dom0-image-rescue-initramfs/dom0-image-rescue-initramfs.bbappend
@@ -1,7 +1,8 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 FILESEXTRAPATHS_prepend := "${THISDIR}/../../inc:"
 
-do_fetch[depends] += "domd-agl-demo-platform:do_${BB_DEFAULT_TASK}"
+do_configure[depends] += "domd-image-weston:do_domd_install_machine_overrides"
+do_compile[depends] += "domd-image-weston:do_${BB_DEFAULT_TASK}"
 
 SRC_URI = " \
     repo://github.com/xen-troops/manifests;protocol=https;branch=master;manifest=prod_devel/dom0.xml;scmdata=keep \

--- a/recipes-dom0/dom0-image-thin-initramfs/dom0-image-thin-initramfs.bbappend
+++ b/recipes-dom0/dom0-image-thin-initramfs/dom0-image-thin-initramfs.bbappend
@@ -1,7 +1,8 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 FILESEXTRAPATHS_prepend := "${THISDIR}/../../inc:"
 
-do_fetch[depends] += "domd-image-weston:do_${BB_DEFAULT_TASK}"
+do_configure[depends] += "domd-image-weston:do_domd_install_machine_overrides"
+do_compile[depends] += "domd-image-weston:do_${BB_DEFAULT_TASK}"
 
 XT_GUESTS_BUILD ?= "doma domf"
 XT_GUESTS_INSTALL ?= "doma domf"
@@ -9,11 +10,11 @@ XT_GUESTS_INSTALL ?= "doma domf"
 python __anonymous () {
     guests = d.getVar('XT_GUESTS_BUILD', True).split()
     if "doma" in guests :
-        d.appendVarFlag("do_fetch", "depends", " domu-image-android:do_${BB_DEFAULT_TASK} ")
+        d.appendVarFlag("do_compile", "depends", " domu-image-android:do_${BB_DEFAULT_TASK} ")
     if "domf" in guests :
-        d.appendVarFlag("do_fetch", "depends", " domu-image-fusion:do_${BB_DEFAULT_TASK} ")
+        d.appendVarFlag("do_compile", "depends", " domu-image-fusion:do_${BB_DEFAULT_TASK} ")
     if "domr" in guests :
-        d.appendVarFlag("do_fetch", "depends", " domu-image-litmusrt:do_${BB_DEFAULT_TASK} ")
+        d.appendVarFlag("do_compile", "depends", " domu-image-litmusrt:do_${BB_DEFAULT_TASK} ")
 }
 
 ################################################################################

--- a/recipes-domd/domd-image-weston/domd-image-weston.bbappend
+++ b/recipes-domd/domd-image-weston/domd-image-weston.bbappend
@@ -22,6 +22,20 @@ XT_QUIRK_BB_ADD_LAYER += " \
 
 XT_BB_IMAGE_TARGET = "core-image-weston"
 
+
+# Dom0 is a generic ARMv8 machine w/o machine overrides,
+# but still needs to know which system we are building,
+# e.g. Salvator-X M3 or H3, for instance
+# So, we provide machine overrides from this build the domain.
+# The same is true for Android build.
+addtask domd_install_machine_overrides after do_configure before do_compile
+python do_domd_install_machine_overrides() {
+    bb.debug(1, "Installing machine overrides")
+
+    d.setVar('XT_BB_CMDLINE', "-f domd-install-machine-overrides")
+    bb.build.exec_func("build_yocto_exec_bitbake", d)
+}
+
 ################################################################################
 # Renesas R-Car
 ################################################################################

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-extended/domd-install-machine-overrides/domd-install-machine-overrides.bb
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-extended/domd-install-machine-overrides/domd-install-machine-overrides.bb
@@ -1,5 +1,14 @@
 LICENSE = "CLOSED"
 
+BBCLASSEXTEND = "native"
+
+do_fetch[noexec] = "1"
+do_configure[noexec] = "1"
+
+do_compile() {
+    :
+}
+
 # FIXME: if not forced and sstate cache is used then an old version of
 # this package (read old DomU kernel images) can be used from cache
 # regardless of the fact that binaries may have actually changed, e.g.

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-graphics/images/core-image-weston.bbappend
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-graphics/images/core-image-weston.bbappend
@@ -19,12 +19,6 @@ EXTRA_IMAGEDEPENDS += " arm-trusted-firmware"
 # u-boot
 DEPENDS += " u-boot"
 
-# Dom0 is a generic ARMv8 machine w/o machine overrides,
-# but still needs to know which system we are building,
-# e.g. Salvator-X M3 or H3, for instance
-# So, we provide machine overrides from this build to Dom0
-EXTRA_IMAGEDEPENDS += " domd-install-machine-overrides"
-
 # Do not support secure environment
 IMAGE_INSTALL_remove = " \
     optee-linuxdriver \

--- a/recipes-domu/domu-image-android/domu-image-android.bbappend
+++ b/recipes-domu/domu-image-android/domu-image-android.bbappend
@@ -2,7 +2,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 FILESEXTRAPATHS_prepend := "${THISDIR}/../../inc:"
 
 # we need MACHINEOVERRIDES from DomD build
-do_fetch[depends] += "domd-image-weston:do_${BB_DEFAULT_TASK}"
+do_configure[depends] += "domd-image-weston:do_domd_install_machine_overrides"
 
 XT_BB_LAYERS_FILE = "meta-xt-prod-extra/doc/bblayers.conf.domu-image-android"
 XT_BB_LOCAL_CONF_FILE = "meta-xt-prod-extra/doc/local.conf.domu-image-android"


### PR DESCRIPTION
1. do_fetch can be started in parallel for all domains
2. No need for DomD to be build to the end and produce machine overrides,
this can be done sooner. Thus, allow DomA to start building sooner.

Note: domd-install-machine-override recipe is implemented as a native
one, thus there is still room to optimize that: native recipes make
Yocto build some native dependencies, but for domd-install-machine-override
those are not needed. Removing such a dependency will allow providing
overrides before building the required native packages (470 at the moment).
Those will still be used during the domain build, but providing
overrides sooner means running DomA build sooner.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>