### PR TITLE
Set an explicit dependency on weston for displbe and display-manager

### DIFF
--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/display-manager.service
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/display-manager.service
@@ -7,9 +7,10 @@ Before=HomeScreen.service
 Environment="XDG_RUNTIME_DIR=/run/user/0"
 Type=dbus
 BusName=com.epam.DisplayManager
+ExecStartPre=/usr/bin/weston-info
 ExecStart=/usr/bin/display_manager -c /xt/cfg/dm.cfg
 Restart=on-failure
-RestartSec=1
+RestartSec=4
 
 [Install]
 WantedBy=default.target

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/displbe.service
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/displbe.service
@@ -6,12 +6,13 @@ After=proc-xen.mount weston.service
 [Service]
 Type=simple
 Environment="XDG_RUNTIME_DIR=/run/user/0"
-ExecStartPre=/bin/sleep 1
+ExecStartPre=/usr/bin/weston-info
 ExecStart=/usr/bin/displ_be
 ExecStartPost=/usr/bin/xenstore-write drivers/displbe/status ready
 ExecStop=/usr/bin/xenstore-write drivers/displbe/status dead
 ExecStopPost=/usr/bin/xenstore-write drivers/displbe/status dead
 Restart=always
+RestartSec=4
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Both displbe and display-manager are dependent on weston to get run.
Due to the fact that we do not have them implemented as daemons yet,
we should get a check on weston availability first in order to avoid
nasty races in the system. Use weston-info as a checker for now.
4 seconds timeout is enough to get it started from SD card and do not
hit restart rate threshold.

Signed-off-by: Andrii Anisov <andrii_anisov@epam.com>