### PR TITLE
Fix to get sensors-emulator running in DomD

### DIFF
--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-extended/sensors-emulator/sensors-emulator.bb
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-extended/sensors-emulator/sensors-emulator.bb
@@ -32,6 +32,7 @@ RDEPENDS_${PN} = " \
     python3-compression \
     python3-argparse \
     python3-textutils \
+    python3-netserver \
 "
 
 inherit systemd


### PR DESCRIPTION
Sensors emulator needs socketserver module. So add a netserv package
which includes socketserver to the system.

Signed-off-by: Andrii Anisov <andrii_anisov@epam.com>