### PR TITLE
dom0: Fix installed domain artifacts

### DIFF
--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-core/images/core-image-thin-initramfs.bbappend
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-core/images/core-image-thin-initramfs.bbappend
@@ -15,7 +15,7 @@ IMAGE_INSTALL_append = " \
     domd-install-artifacts \
 "
 
-XT_GUESTS_INSTALL = "doma domf"
+XT_GUESTS_INSTALL ?= "doma domf"
 
 python __anonymous () {
     guests = d.getVar("XT_GUESTS_INSTALL", True).split()


### PR DESCRIPTION
While checking for wich doamain artifact must be installed
the default values must be weak, so one can override the
default settings.

Fixes: d8b048c11692 ("Explicitly add XT_GUESTS_INSTALL variable into the recipe")

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>