### PR TITLE
domd: Fix Salvator-X M3 device tree build

### DIFF
--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas_%.bbappend
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas_%.bbappend
@@ -79,9 +79,9 @@ SRC_URI_append_salvator-x-m3-xt = " \
 "
 
 KERNEL_DEVICETREE_salvator-x-m3-xt = " \
-    renesas/r8a7796-salvator-x-dom0.dts \
-    renesas/r8a7796-salvator-x-domd.dts \
-    renesas/r8a7795-salvator-x-4x2g-doma.dts \
+    renesas/r8a7796-salvator-x-dom0.dtb \
+    renesas/r8a7796-salvator-x-domd.dtb \
+    renesas/r8a7795-salvator-x-4x2g-doma.dtb \
 "
 
 do_deploy_append() {


### PR DESCRIPTION
Device tree names must be provided as .dtb, not .dts,
so those are built with the kernel.

Fixes: 8fe2a7da1c81 ("Add Salvator-X M3 device trees to the kernel build")

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>