### PR TITLE
domd: Fix error if XT_GUESTS_INSTALL is not set

### DIFF
--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-graphics/wayland/weston_%.bbappend
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-graphics/wayland/weston_%.bbappend
@@ -7,7 +7,7 @@ FILESEXTRAPATHS_append := ":${THISDIR}/${PN}"
 # This is a workaround as display manager and backend are still
 # built with ivi-extensions.
 python __anonymous () {
-    guests = d.getVar("XT_GUESTS_INSTALL", True).split()
+    guests = (d.getVar("XT_GUESTS_INSTALL", True) or "").split()
     if "domu" not in guests :
         d.appendVar("EXTRA_OECONF", " --enable-ivi-shell")
 }


### PR DESCRIPTION
Make a proper check if XT_GUESTS_INSTALL environment variable is set.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>