### PR TITLE
domd: Fix RCAR proprietary DDK archive names

### DIFF
--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-graphics/rcar-proprietary-graphic/prepare-graphic-package.bb
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-graphics/rcar-proprietary-graphic/prepare-graphic-package.bb
@@ -10,7 +10,7 @@ do_install () {
     if [ -d ${DEPLOY_DIR_IMAGE}/xt-rcar ]; then
         cd ${DEPLOY_DIR_IMAGE}
         date --rfc-3339=seconds > version.txt
-        tar -czf rcar-proprietary-graphic-${MACHINE}-domu.tar.gz xt-rcar version.txt
+        tar -czf rcar-proprietary-graphic-${MACHINE}-domd.tar.gz xt-rcar version.txt
         rm version.txt
         rm -rf xt-rcar
     fi

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-graphics/rcar-proprietary-graphic/rcar-proprietary-graphic.bb
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-graphics/rcar-proprietary-graphic/rcar-proprietary-graphic.bb
@@ -11,9 +11,9 @@ PACKAGE_ARCH = "${MACHINE_ARCH}"
 S = "${WORKDIR}/xt-rcar"
 GLES = "gsx"
 
-SRC_URI_r8a7795 = "file://rcar-proprietary-graphic-salvator-x-h3-xt-domu.tar.gz"
-SRC_URI_r8a7796 = "file://rcar-proprietary-graphic-salvator-x-m3-xt-domu.tar.gz"
-SRC_URI_r8a77965 = "file://rcar-proprietary-graphic-salvator-x-m3n-xt-domu.tar.gz"
+SRC_URI_r8a7795 = "file://rcar-proprietary-graphic-salvator-x-h3-xt-domd.tar.gz"
+SRC_URI_r8a7796 = "file://rcar-proprietary-graphic-salvator-x-m3-xt-domd.tar.gz"
+SRC_URI_r8a77965 = "file://rcar-proprietary-graphic-salvator-x-m3n-xt-domd.tar.gz"
 
 inherit update-rc.d systemd
 


### PR DESCRIPTION
Fix RCAR proprietary DDK archive names to contain "domd"
instead of "domu".

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>