### PR TITLE
domd/domu: Use unified name for proprietary DDK binaries

### DIFF
--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-graphics/rcar-proprietary-graphic/rcar-proprietary-graphic.bb
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-graphics/rcar-proprietary-graphic/rcar-proprietary-graphic.bb
@@ -11,9 +11,7 @@ PACKAGE_ARCH = "${MACHINE_ARCH}"
 S = "${WORKDIR}/xt-rcar"
 GLES = "gsx"
 
-SRC_URI_r8a7795 = "file://rcar-proprietary-graphic-salvator-x-h3-xt-domd.tar.gz"
-SRC_URI_r8a7796 = "file://rcar-proprietary-graphic-salvator-x-m3-xt-domd.tar.gz"
-SRC_URI_r8a77965 = "file://rcar-proprietary-graphic-salvator-x-m3n-xt-domd.tar.gz"
+SRC_URI = "file://rcar-proprietary-graphic-${MACHINE}-domd.tar.gz"
 
 inherit update-rc.d systemd
 

--- a/recipes-domu/domu-image-weston/files/meta-xt-prod-extra/recipes-graphics/rcar-proprietary-graphic/rcar-proprietary-graphic.bb
+++ b/recipes-domu/domu-image-weston/files/meta-xt-prod-extra/recipes-graphics/rcar-proprietary-graphic/rcar-proprietary-graphic.bb
@@ -11,9 +11,7 @@ PACKAGE_ARCH = "${MACHINE_ARCH}"
 S = "${WORKDIR}/xt-rcar"
 GLES = "gsx"
 
-SRC_URI_r8a7795 = "file://rcar-proprietary-graphic-salvator-x-h3-xt-domu.tar.gz"
-SRC_URI_r8a7796 = "file://rcar-proprietary-graphic-salvator-x-m3-xt-domu.tar.gz"
-SRC_URI_r8a77965 = "file://rcar-proprietary-graphic-salvator-x-m3n-xt-domu.tar.gz"
+SRC_URI = "file://rcar-proprietary-graphic-${MACHINE}-domu.tar.gz"
 
 inherit update-rc.d systemd
 


### PR DESCRIPTION
While preparing archives with the graphics DDK binaries we use
${MACHINE} based archive names in SRC_URI while using external
binaries with graphics later we open code those. Fix this by
making rcar-proprietary-graphic recipe use the same approach
as prepare-graphic-package does.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>