### PR TITLE
domd/domu: Fix GLES header dependency for provided DDK

### DIFF
--- a/recipes-domd/domd-image-weston/domd-image-weston.bbappend
+++ b/recipes-domd/domd-image-weston/domd-image-weston.bbappend
@@ -78,11 +78,13 @@ configure_versions_rcar() {
         base_set_conf_value ${local_conf} PREFERRED_PROVIDER_kernel-module-dc-linuxfb "rcar-proprietary-graphic"
         base_set_conf_value ${local_conf} PREFERRED_PROVIDER_kernel-module-gles "rcar-proprietary-graphic"
         base_set_conf_value ${local_conf} PREFERRED_PROVIDER_gles-user-module "rcar-proprietary-graphic"
+        base_set_conf_value ${local_conf} PREFERRED_PROVIDER_gles-module-egl-headers = "rcar-proprietary-graphic"
         base_add_conf_value ${local_conf} BBMASK "meta-xt-images-vgpu/recipes-graphics/gles-module/"
         base_add_conf_value ${local_conf} BBMASK "meta-xt-prod-extra/recipes-graphics/gles-module/"
         base_add_conf_value ${local_conf} BBMASK "meta-xt-prod-vgpu/recipes-graphics/gles-module/"
         base_add_conf_value ${local_conf} BBMASK "meta-xt-prod-vgpu/recipes-graphics/wayland/"
         base_add_conf_value ${local_conf} BBMASK "meta-xt-prod-vgpu/recipes-kernel/kernel-module-gles/"
+        base_add_conf_value ${local_conf} BBMASK "meta-xt-images-vgpu/recipes-kernel/kernel-module-gles/"
         base_add_conf_value ${local_conf} BBMASK "meta-renesas/meta-rcar-gen3/recipes-kernel/kernel-module-gles/"
         base_add_conf_value ${local_conf} BBMASK "meta-renesas/meta-rcar-gen3/recipes-graphics/gles-module/"
         xt_unpack_proprietary

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-graphics/rcar-proprietary-graphic/rcar-proprietary-graphic.bb
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-graphics/rcar-proprietary-graphic/rcar-proprietary-graphic.bb
@@ -97,7 +97,14 @@ FILES_${PN} = " \
     ${libdir}/pkgconfig/* \
 "
 
-PROVIDES = "virtual/libgles2 virtual/egl kernel-module-gles gles-user-module"
+PROVIDES = " \
+    virtual/libgles2 \
+    virtual/egl \
+    kernel-module-gles \
+    gles-user-module \
+    gles-module-egl-headers \
+"
+
 RPROVIDES_${PN} += " \
     kernel-module-pvrsrvkm \
     kernel-module-dc-linuxfb \

--- a/recipes-domu/domu-image-weston/domu-image-weston.bbappend
+++ b/recipes-domu/domu-image-weston/domu-image-weston.bbappend
@@ -61,11 +61,13 @@ configure_versions_rcar() {
         base_set_conf_value ${local_conf} PREFERRED_PROVIDER_kernel-module-dc-linuxfb "rcar-proprietary-graphic"
         base_set_conf_value ${local_conf} PREFERRED_PROVIDER_kernel-module-gles "rcar-proprietary-graphic"
         base_set_conf_value ${local_conf} PREFERRED_PROVIDER_gles-user-module "rcar-proprietary-graphic"
+        base_set_conf_value ${local_conf} PREFERRED_PROVIDER_gles-module-egl-headers = "rcar-proprietary-graphic"
         base_add_conf_value ${local_conf} BBMASK "meta-xt-images-vgpu/recipes-graphics/gles-module/"
         base_add_conf_value ${local_conf} BBMASK "meta-xt-prod-extra/recipes-graphics/gles-module/"
         base_add_conf_value ${local_conf} BBMASK "meta-xt-prod-vgpu/recipes-graphics/gles-module/"
         base_add_conf_value ${local_conf} BBMASK "meta-xt-prod-vgpu/recipes-graphics/wayland/"
         base_add_conf_value ${local_conf} BBMASK "meta-xt-prod-vgpu/recipes-kernel/kernel-module-gles/"
+        base_add_conf_value ${local_conf} BBMASK "meta-xt-images-vgpu/recipes-kernel/kernel-module-gles/"
         base_add_conf_value ${local_conf} BBMASK "meta-renesas/meta-rcar-gen3/recipes-kernel/kernel-module-gles/"
         base_add_conf_value ${local_conf} BBMASK "meta-renesas/meta-rcar-gen3/recipes-graphics/gles-module/"
         xt_unpack_proprietary

--- a/recipes-domu/domu-image-weston/files/meta-xt-prod-extra/recipes-graphics/rcar-proprietary-graphic/rcar-proprietary-graphic.bb
+++ b/recipes-domu/domu-image-weston/files/meta-xt-prod-extra/recipes-graphics/rcar-proprietary-graphic/rcar-proprietary-graphic.bb
@@ -97,7 +97,14 @@ FILES_${PN} = " \
     ${libdir}/pkgconfig/* \
 "
 
-PROVIDES = "virtual/libgles2 virtual/egl kernel-module-gles gles-user-module"
+PROVIDES = " \
+    virtual/libgles2 \
+    virtual/egl \
+    kernel-module-gles \
+    gles-user-module \
+    gles-module-egl-headers \
+"
+
 RPROVIDES_${PN} += " \
     kernel-module-pvrsrvkm \
     kernel-module-dc-linuxfb \


### PR DESCRIPTION
When DDK is provided in a binary form, e.g. is not built from
sources, the dependency for GLES headers is still the sources.
Fix this by making binary package the provider of the headers.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>