### PR TITLE
domd: Do not try installing packagegroup-graphics-renesas-proprietary

### DIFF
--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-graphics/images/core-image-weston.bbappend
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-graphics/images/core-image-weston.bbappend
@@ -27,6 +27,11 @@ IMAGE_INSTALL_remove = " \
     libx11-locale \
 "
 
+# Use only provided proprietary graphic modules
+IMAGE_INSTALL_remove = " \
+    packagegroup-graphics-renesas-proprietary \
+"
+
 CORE_IMAGE_BASE_INSTALL_remove += "gtk+3-demo clutter-1.0-examples"
 
 populate_vmlinux () {


### PR DESCRIPTION
packagegroup-graphics-renesas-proprietary is about to be used
to pack graphics DDK binaries into an archive, but it is not
intended to be installed into the final image.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>