### PR TITLE
domd: Build DomU device tree for Salvator-X H3 ES2.0

### DIFF
--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas_%.bbappend
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas_%.bbappend
@@ -56,12 +56,13 @@ KERNEL_DEVICETREE_salvator-x-h3-4x2g-xt = " \
 ###############################################################################
 # N.B. Device trees for ES 2.0 are based on and use device trees
 # for Salvator-X H3 ES3.0 4x2G: Dom0 has memory and GSX adjustments
-# and DomD and DomA are used as is.
+# and DomD and DomA and DomU are used as is.
 ###############################################################################
 SRC_URI_append_salvator-x-h3-xt = " \
     file://r8a7795-salvator-x-4x2g-dom0.dts;subdir=git/arch/${ARCH}/boot/dts/renesas \
     file://r8a7795-salvator-x-4x2g-domd.dts;subdir=git/arch/${ARCH}/boot/dts/renesas \
     file://r8a7795-salvator-x-4x2g-doma.dts;subdir=git/arch/${ARCH}/boot/dts/renesas \
+    file://r8a7795-salvator-x-4x2g-domu.dts;subdir=git/arch/${ARCH}/boot/dts/renesas \
     file://r8a7795-salvator-x-dom0.dts;subdir=git/arch/${ARCH}/boot/dts/renesas \
 "
 
@@ -69,6 +70,7 @@ KERNEL_DEVICETREE_salvator-x-h3-xt = " \
     renesas/r8a7795-salvator-x-dom0.dtb \
     renesas/r8a7795-salvator-x-4x2g-domd.dtb \
     renesas/r8a7795-salvator-x-4x2g-doma.dtb \
+    renesas/r8a7795-salvator-x-4x2g-domu.dtb \
 "
 
 ##############################################################################


### PR DESCRIPTION
Build DomU device tree for Salvator-X H3 ES2.0 from
Salvator-X H3 ES3.0 as those are identical.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>