### PR TITLE
Revert "domd: Do not build displbe with IVI extensions if no ivi-shell"

### DIFF
--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-extended/displbe/displbe_git.bbappend
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-extended/displbe/displbe_git.bbappend
@@ -5,20 +5,6 @@ SRCREV_rcar = "${AUTOREV}"
 
 SRC_URI_append_rcar = " git://github.com/xen-troops/displ_be.git;protocol=https;branch=master"
 
-DEPENDS += " wayland-native"
+DEPENDS += " wayland-ivi-extension wayland-native"
 
-EXTRA_OECMAKE_append_rcar = " -DWITH_DOC=OFF -DWITH_DRM=ON -DWITH_ZCOPY=ON -DWITH_WAYLAND=ON -DWITH_INPUT=ON"
-
-USE_IVI_EXTENSION = "${@'1' if 'ivi-shell' in '${DISTRO_FEATURES}' else '0'}"
-
-DEPENDS_append = " \
-    ${@base_conditional('USE_IVI_EXTENSION', '1', ' wayland-ivi-extension', '', d)}"
-
-EXTRA_OECMAKE_append_rcar = " \
-    ${@base_conditional('USE_IVI_EXTENSION', '1', '', \
-        ' -DWITH_IVI_EXTENSION=ON', d)}"
-
-EXTRA_OECMAKE_append_rcar = " \
-    ${@base_conditional('USE_IVI_EXTENSION', '0', '', \
-        ' -DWITH_IVI_EXTENSION=OFF', d)}"
-
+EXTRA_OECMAKE_append_rcar = " -DWITH_DOC=OFF -DWITH_DRM=ON -DWITH_ZCOPY=ON -DWITH_WAYLAND=ON -DWITH_IVI_EXTENSION=ON -DWITH_INPUT=ON"


### PR DESCRIPTION
This reverts commit 8126ad7f745628f3c8c41b639aabd238d4bac9bf.

The commit does break the default prod-devel build.

Signed-off-by: Andrii Anisov <andrii_anisov@epam.com>