### PR TITLE
Fix libconfig recipe

### DIFF
--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-extended/libconfig/libconfig_1.5.bbappend
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-extended/libconfig/libconfig_1.5.bbappend
@@ -1,5 +1,3 @@
 SRC_URI = "git://github.com/hyperrealm/libconfig.git;tag=v1.5"
 
 S = "${WORKDIR}/git"
-
-inherit cmake autotools-brokensep pkgconfig


### PR DESCRIPTION
libconfig v1.5 does not contain CMake file, so avoid using cmake.
Also inheritance of autotools-brokensep and pkgconfig is already
in original recipe, so cleanup double inheritance.

Signed-off-by: Iurii Artemenko <iurii_artemenko@epam.com>