### PR TITLE
Set Linux kernel version to 4.14.35

### DIFF
--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-kernel/linux/linux-generic-armv8.bbappend
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-kernel/linux/linux-generic-armv8.bbappend
@@ -2,6 +2,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
 BRANCH = "master"
 SRCREV = "${AUTOREV}"
+LINUX_VERSION = "4.14.35"
 
 SRC_URI = " \
     git://github.com/xen-troops/linux.git;branch=${BRANCH} \

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux-libc-headers/linux-libc-headers_%.bbappend
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux-libc-headers/linux-libc-headers_%.bbappend
@@ -1,4 +1,5 @@
 RENESAS_BSP_URL = "git://github.com/xen-troops/linux.git"
 
-BRANCH = "v4.14-rcar-3.7.0-xt0.1"
+BRANCH = "master"
 SRCREV = "${AUTOREV}"
+LINUX_VERSION = "4.14.35"

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas_%.bbappend
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas_%.bbappend
@@ -4,8 +4,9 @@ require inc/xt_shared_env.inc
 
 RENESAS_BSP_URL = "git://github.com/xen-troops/linux.git"
 
-BRANCH = "v4.14-rcar-3.7.0-xt0.1"
+BRANCH = "master"
 SRCREV = "${AUTOREV}"
+LINUX_VERSION = "4.14.35"
 SRC_URI_append = " \
     file://defconfig \
 "

--- a/recipes-domu/domu-image-fusion/files/meta-xt-prod-extra/recipes-kernel/linux/linux-generic-armv8.bbappend
+++ b/recipes-domu/domu-image-fusion/files/meta-xt-prod-extra/recipes-kernel/linux/linux-generic-armv8.bbappend
@@ -4,6 +4,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
 BRANCH = "master"
 SRCREV = "${AUTOREV}"
+LINUX_VERSION = "4.14.35"
 
 SRC_URI = " \
     git://github.com/xen-troops/linux.git;branch=${BRANCH} \

--- a/recipes-domu/domu-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux-libc-headers/linux-libc-headers_%.bbappend
+++ b/recipes-domu/domu-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux-libc-headers/linux-libc-headers_%.bbappend
@@ -2,3 +2,4 @@ RENESAS_BSP_URL = "git://github.com/xen-troops/linux.git"
 
 BRANCH = "master"
 SRCREV = "${AUTOREV}"
+LINUX_VERSION = "4.14.35"

--- a/recipes-domu/domu-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas_%.bbappend
+++ b/recipes-domu/domu-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas_%.bbappend
@@ -6,6 +6,7 @@ RENESAS_BSP_URL = "git://github.com/xen-troops/linux.git"
 
 BRANCH = "master"
 SRCREV = "${AUTOREV}"
+LINUX_VERSION = "4.14.35"
 SRC_URI_append = " \
     file://defconfig \
 "


### PR DESCRIPTION
Assign LINUX_VERSION in the current product`s recipes so commit
7d7ffd91787ea89196c1664ff48bf5fd98370cec can be reverted from
meta-xt-images layer.

Signed-off-by: Iurii Artemenko <iurii_artemenko@epam.com>