### PR TITLE
Disable hardware keyboard for DomA

### DIFF
--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/doma-salvator-x-h3-4x2g.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/doma-salvator-x-h3-4x2g.cfg
@@ -53,7 +53,7 @@ vif = [ 'backend=DomD,bridge=xenbr0,mac=08:00:27:ff:cb:ce' ]
 #     * we use 1088 to be aligned with tile 32 (pixels), it will be scaled to 1080 by DisplayManager.
 vdispl = [ 'backend=DomD,be-alloc=0,connectors=1000:1920x1080;1001:768x1024' ]
 
-vkb = [ 'backend=DomD,backend-type=linux,multi-touch-width=1920,multi-touch-height=1080,multi-touch-num-contacts=10,unique-id=T:1000' ]
+vkb = [ 'backend=DomD,backend-type=linux,multi-touch-width=1920,multi-touch-height=1080,multi-touch-num-contacts=10,feature-disable-keyboard=1,unique-id=T:1000' ]
 
 vsnd = [[ 'card, backend=DomD, buffer-size=65536, short-name=VCard, long-name=Virtual sound card, sample-rates=48000, sample-formats=s16_le',
           'pcm, name=dev1', 'stream, unique-id=pulse, type=P', 'stream, unique-id=pulse, type=C' ]]

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/doma-salvator-x-h3.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/doma-salvator-x-h3.cfg
@@ -49,7 +49,7 @@ vif = [ 'backend=DomD,bridge=xenbr0,mac=08:00:27:ff:cb:ce' ]
 #     * we use 1088 to be aligned with tile 32 (pixels), it will be scaled to 1080 by DisplayManager.
 vdispl = [ 'backend=DomD,be-alloc=0,connectors=1000:1920x1080;1001:768x1024' ]
 
-vkb = [ 'backend=DomD,backend-type=linux,multi-touch-width=1920,multi-touch-height=1080,multi-touch-num-contacts=10,unique-id=T:1000' ]
+vkb = [ 'backend=DomD,backend-type=linux,multi-touch-width=1920,multi-touch-height=1080,multi-touch-num-contacts=10,feature-disable-keyboard=1,unique-id=T:1000' ]
 
 vsnd = [[ 'card, backend=DomD, buffer-size=65536, short-name=VCard, long-name=Virtual sound card, sample-rates=48000, sample-formats=s16_le',
           'pcm, name=dev1', 'stream, unique-id=pulse, type=P', 'stream, unique-id=pulse, type=C' ]]

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/doma-salvator-x-m3.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/doma-salvator-x-m3.cfg
@@ -49,7 +49,7 @@ vif = [ 'backend=DomD,bridge=xenbr0,mac=08:00:27:ff:cb:ce' ]
 #     * we use 1088 to be aligned with tile 32 (pixels), it will be scaled to 1080 by DisplayManager.
 vdispl = [ 'backend=DomD,be-alloc=0,connectors=1000:1920x1080;1001:768x1024' ]
 
-vkb = [ 'backend=DomD,backend-type=linux,multi-touch-width=1920,multi-touch-height=1080,multi-touch-num-contacts=10,unique-id=T:1000' ]
+vkb = [ 'backend=DomD,backend-type=linux,multi-touch-width=1920,multi-touch-height=1080,multi-touch-num-contacts=10,feature-disable-keyboard=1,unique-id=T:1000' ]
 
 vsnd = [[ 'card, backend=DomD, buffer-size=65536, short-name=VCard, long-name=Virtual sound card, sample-rates=48000, sample-formats=s16_le',
           'pcm, name=dev1', 'stream, unique-id=pulse, type=P', 'stream, unique-id=pulse, type=C' ]]

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/doma-salvator-xs-h3.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/doma-salvator-xs-h3.cfg
@@ -49,7 +49,7 @@ vif = [ 'backend=DomD,bridge=xenbr0,mac=08:00:27:ff:cb:ce' ]
 #     * we use 1088 to be aligned with tile 32 (pixels), it will be scaled to 1080 by DisplayManager.
 vdispl = [ 'backend=DomD,be-alloc=0,connectors=1000:1920x1080;1001:768x1024' ]
 
-vkb = [ 'backend=DomD,backend-type=linux,multi-touch-width=1920,multi-touch-height=1080,multi-touch-num-contacts=10,unique-id=T:1000' ]
+vkb = [ 'backend=DomD,backend-type=linux,multi-touch-width=1920,multi-touch-height=1080,multi-touch-num-contacts=10,feature-disable-keyboard=1,unique-id=T:1000' ]
 
 vsnd = [[ 'card, backend=DomD, buffer-size=65536, short-name=VCard, long-name=Virtual sound card, sample-rates=48000, sample-formats=s16_le',
           'pcm, name=dev1', 'stream, unique-id=pulse, type=P', 'stream, unique-id=pulse, type=C' ]]


### PR DESCRIPTION
If hw keyboard is enabled, Android will not
show onscreen keyboard.

Signed-off-by: Andrii Chepurnyi <andrii_chepurnyi@epam.com>