### PR TITLE
Set default volume for audio record

### DIFF
--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-bsp/alsa-state/files/asound.state
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-bsp/alsa-state/files/asound.state
@@ -220,8 +220,8 @@ state.rsnddai0ak4613h {
 	control.14 {
 		iface MIXER
 		name 'DVC In Capture Volume'
-		value.0 0
-		value.1 0
+		value.0 6710885
+		value.1 6710885
 		comment {
 			access 'read write'
 			type INTEGER


### PR DESCRIPTION
Enable audio input by setting input volume to 80% of max.

Signed-off-by: Ruslan Shymkevych <ruslan_shymkevych@epam.com>