### PR TITLE
Change default patch tool

### DIFF
--- a/recipes-domu/domu-image-android/files/meta-xt-prod-extra/recipes-extended/android/android.bbappend
+++ b/recipes-domu/domu-image-android/files/meta-xt-prod-extra/recipes-extended/android/android.bbappend
@@ -20,6 +20,7 @@ EXTRA_OEMAKE_append = " \
 
 ANDROID_KERNEL_NAME ?= "kernel"
 ANDROID_UNPACKED_KERNEL_NAME ?= "vmlinux"
+PATCHTOOL = "git"
 
 ################################################################################
 # Renesas R-Car


### PR DESCRIPTION
Yocto`s default patch tool 'quilt' duplicates pathed file,
in this case Android.bp, which causing ninja compiler to failure.
So, we have to use 'git' as a patch tool.

Signed-off-by: Iurii Artemenko <iurii_artemenko@epam.com>