### PR TITLE
Build reconstruction: All domains must use manifests without open coding...

### DIFF
--- a/recipes-domd/domd-image-weston/domd-image-weston.bbappend
+++ b/recipes-domd/domd-image-weston/domd-image-weston.bbappend
@@ -14,10 +14,6 @@ SRC_URI = " \
     repo://github.com/xen-troops/manifests;protocol=https;branch=master;manifest=${XT_MANIFEST_FOLDER}/domd.xml;scmdata=keep \
 "
 
-SRC_URI_append = " \
-    git://github.com/kraj/meta-clang.git;destsuffix=repo/meta-clang;branch=rocko \
-"
-
 XT_QUIRK_UNPACK_SRC_URI += " \
     file://meta-xt-prod-extra;subdir=repo \
     file://xt_shared_env.inc;subdir=repo/meta-xt-prod-extra/inc \
@@ -25,7 +21,6 @@ XT_QUIRK_UNPACK_SRC_URI += " \
 
 XT_QUIRK_BB_ADD_LAYER += " \
     meta-xt-prod-extra \
-    meta-clang \
 "
 
 XT_BB_IMAGE_TARGET = "core-image-weston"

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/doc/bblayers.conf.rcar-domd-image-weston
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/doc/bblayers.conf.rcar-domd-image-weston
@@ -16,6 +16,7 @@ BBLAYERS ?= " \
   ${TOPDIR}/../meta-openembedded/meta-python \
   ${TOPDIR}/../meta-selinux \
   ${TOPDIR}/../meta-virtualization \
+  ${TOPDIR}/../meta-clang \
   "
 BBLAYERS_NON_REMOVABLE ?= " \
   ${TOPDIR}/../poky/meta \

--- a/recipes-domu/domu-image-android/domu-image-android.bbappend
+++ b/recipes-domu/domu-image-android/domu-image-android.bbappend
@@ -4,6 +4,10 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/../../inc:"
 # we need MACHINEOVERRIDES from DomD build
 do_configure[depends] += "domd-image-weston:do_domd_install_machine_overrides"
 
+SRC_URI = " \
+    repo://github.com/xen-troops/manifests;protocol=https;branch=master;manifest=prod_devel/domu_android_host_tools.xml;scmdata=keep \
+"
+
 XT_BB_LAYERS_FILE = "meta-xt-prod-extra/doc/bblayers.conf.domu-image-android"
 XT_BB_LOCAL_CONF_FILE = "meta-xt-prod-extra/doc/local.conf.domu-image-android"
 

--- a/recipes-domu/domu-image-fusion/domu-image-fusion.bbappend
+++ b/recipes-domu/domu-image-fusion/domu-image-fusion.bbappend
@@ -12,7 +12,6 @@ XT_QUIRK_UNPACK_SRC_URI += " \
 "
 
 XT_QUIRK_BB_ADD_LAYER_append = " \
-    meta-golang \
     meta-xt-prod-extra \
 "
 ################################################################################
@@ -21,12 +20,6 @@ XT_QUIRK_BB_ADD_LAYER_append = " \
 SRC_URI += " \
     repo://github.com/xen-troops/manifests;protocol=https;branch=master;manifest=prod_devel/domf.xml;scmdata=keep \
 "
-
-SRC_URI += " \
-    git://github.com/madisongh/meta-golang.git;protocol=https;destsuffix=repo/meta-golang;branch=rocko;name=metago \
-"
-
-SRCREV_metago = "${AUTOREV}"
 
 XT_BB_LAYERS_FILE = "meta-xt-prod-extra/doc/bblayers.conf.domf-image-minimal"
 XT_BB_LOCAL_CONF_FILE = "meta-xt-prod-extra/doc/local.conf.domf-image-minimal"

--- a/recipes-domu/domu-image-fusion/files/meta-xt-prod-extra/doc/bblayers.conf.domf-image-minimal
+++ b/recipes-domu/domu-image-fusion/files/meta-xt-prod-extra/doc/bblayers.conf.domf-image-minimal
@@ -13,6 +13,7 @@ BBLAYERS ?= " \
   ${TOPDIR}/../meta-openembedded/meta-python \
   ${TOPDIR}/../meta-openembedded/meta-networking \
   ${TOPDIR}/../meta-openembedded/meta-filesystems \
+  ${TOPDIR}/../meta-golang \
 "
 
 BBLAYERS_NON_REMOVABLE ?= " \

--- a/recipes-domu/domu-image-litmusrt/domu-image-litmusrt.bbappend
+++ b/recipes-domu/domu-image-litmusrt/domu-image-litmusrt.bbappend
@@ -3,12 +3,8 @@ XT_QUIRK_BB_ADD_LAYER += " \
     meta-litmusrt \
 "
 
-# Set default poky revision to pyro
-BRANCH = "pyro"
-
 SRC_URI = " \
-    git://git.yoctoproject.org/poky;destsuffix=repo/poky;branch=${BRANCH} \
-    git://github.com/xen-troops/meta-litmusrt.git;destsuffix=repo/meta-litmusrt;branch=master \
+    repo://github.com/xen-troops/manifests;protocol=https;branch=master;manifest=prod_devel/domr.xml;scmdata=keep \
 "
 
 SRCREV = "${AUTOREV}"

--- a/recipes-domu/domu-image-weston/domu-image-weston.bbappend
+++ b/recipes-domu/domu-image-weston/domu-image-weston.bbappend
@@ -16,10 +16,6 @@ SRC_URI = " \
     repo://github.com/xen-troops/manifests;protocol=https;branch=master;manifest=${XT_MANIFEST_FOLDER}/domu.xml;scmdata=keep \
 "
 
-SRC_URI_append = " \
-    git://github.com/kraj/meta-clang.git;destsuffix=repo/meta-clang;branch=rocko \
-"
-
 XT_QUIRK_UNPACK_SRC_URI += " \
     file://meta-xt-prod-extra;subdir=repo \
     file://xt_shared_env.inc;subdir=repo/meta-xt-prod-extra/inc \
@@ -27,7 +23,6 @@ XT_QUIRK_UNPACK_SRC_URI += " \
 
 XT_QUIRK_BB_ADD_LAYER += " \
     meta-xt-prod-extra \
-    meta-clang \
 "
 
 XT_BB_IMAGE_TARGET = "core-image-weston"

--- a/recipes-domu/domu-image-weston/files/meta-xt-prod-extra/doc/bblayers.conf.rcar-domu-image-weston
+++ b/recipes-domu/domu-image-weston/files/meta-xt-prod-extra/doc/bblayers.conf.rcar-domu-image-weston
@@ -14,6 +14,7 @@ BBLAYERS ?= " \
   ${TOPDIR}/../meta-openembedded/meta-oe \
   ${TOPDIR}/../meta-openembedded/meta-networking \
   ${TOPDIR}/../meta-openembedded/meta-python \
+  ${TOPDIR}/../meta-clang \
   "
 BBLAYERS_NON_REMOVABLE ?= " \
   ${TOPDIR}/../poky/meta \


### PR DESCRIPTION
additional meta layers in SRC_URI. There are domain recipes
which either do not use manifest files to retrieve the meta
layers used during the build or manually adding meta layers
to existing manifests. All these prevents build reconstruction
to run correctly, so fix these issues.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>