### PR TITLE
Provide 8 playback devices for all devices

### DIFF
--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/doma-salvator-generic.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/doma-salvator-generic.cfg
@@ -54,6 +54,14 @@ vdispl = [ 'backend=DomD,be-alloc=0,connectors=1000:1920x1080;1001:1024x768' ]
 vkb = [ 'backend=DomD,backend-type=linux,multi-touch-width=1920,multi-touch-height=1080,multi-touch-num-contacts=10,feature-disable-keyboard=1,unique-id=T:1000' ]
 
 vsnd = [[ 'card, backend=DomD, buffer-size=65536, short-name=VCard, long-name=Virtual sound card, sample-rates=48000, sample-formats=s16_le',
-          'pcm, name=dev1', 'stream, unique-id=pulse, type=P', 'stream, unique-id=pulse, type=C' ]]
+          'pcm, name=dev1', 'stream, unique-id=pulse, type=P', 'stream, unique-id=pulse, type=C',
+          'pcm, name=dev2', 'stream, unique-id=pulse, type=P',
+          'pcm, name=dev3', 'stream, unique-id=pulse, type=P',
+          'pcm, name=dev4', 'stream, unique-id=pulse, type=P',
+          'pcm, name=dev5', 'stream, unique-id=pulse, type=P',
+          'pcm, name=dev6', 'stream, unique-id=pulse, type=P',
+          'pcm, name=dev7', 'stream, unique-id=pulse, type=P',
+          'pcm, name=dev8', 'stream, unique-id=pulse, type=P'
+       ]]
 
 on_crash = 'preserve'

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/doma-salvator-x-h3-4x2g.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/doma-salvator-x-h3-4x2g.cfg
@@ -58,6 +58,14 @@ vdispl = [ 'backend=DomD,be-alloc=0,connectors=1000:1920x1080;1001:1024x768' ]
 vkb = [ 'backend=DomD,backend-type=linux,multi-touch-width=1920,multi-touch-height=1080,multi-touch-num-contacts=10,feature-disable-keyboard=1,unique-id=T:1000' ]
 
 vsnd = [[ 'card, backend=DomD, buffer-size=65536, short-name=VCard, long-name=Virtual sound card, sample-rates=48000, sample-formats=s16_le',
-          'pcm, name=dev1', 'stream, unique-id=pulse, type=P', 'stream, unique-id=pulse, type=C' ]]
+          'pcm, name=dev1', 'stream, unique-id=pulse, type=P', 'stream, unique-id=pulse, type=C',
+          'pcm, name=dev2', 'stream, unique-id=pulse, type=P',
+          'pcm, name=dev3', 'stream, unique-id=pulse, type=P',
+          'pcm, name=dev4', 'stream, unique-id=pulse, type=P',
+          'pcm, name=dev5', 'stream, unique-id=pulse, type=P',
+          'pcm, name=dev6', 'stream, unique-id=pulse, type=P',
+          'pcm, name=dev7', 'stream, unique-id=pulse, type=P',
+          'pcm, name=dev8', 'stream, unique-id=pulse, type=P'
+       ]]
 
 on_crash = 'preserve'


### PR DESCRIPTION
Separate playback devices are provided for support of Android's
automotive audio buses.
For now we can have max 8 buses (media, navi, radio, etc).

Signed-off-by: Ruslan Shymkevych <ruslan_shymkevych@epam.com>