### PR TITLE
r8a7795-salvator-x-4x2g-domd: Try to low SD/EMMC speed

### DIFF
--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas/r8a7795-salvator-x-4x2g-domd.dts
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas/r8a7795-salvator-x-4x2g-domd.dts
@@ -88,3 +88,11 @@
 &sata {
 	status = "disabled";
 };
+
+&sdhi0 {
+	/delete-property/ sd-uhs-sdr104;
+};
+
+&sdhi2 {
+	/delete-property/ mmc-hs400-1_8v;
+};


### PR DESCRIPTION
Just removing the highest HS400 mode for eMMC avoids read/write
errors on a heavy loads.

Signed-off-by: Oleksandr Tyshchenko <oleksandr_tyshchenko@epam.com>
Tested-by: Andrii Chepurnyi <andrii_chepurnyi@epam.com>