### PR TITLE
Add manifest folder name

### DIFF
--- a/recipes-domd/domd-image-weston/domd-image-weston.bbappend
+++ b/recipes-domd/domd-image-weston/domd-image-weston.bbappend
@@ -2,8 +2,16 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 FILESEXTRAPATHS_prepend := "${THISDIR}/../../inc:"
 FILESEXTRAPATHS_prepend := "${THISDIR}/../../recipes-domx:"
 
+XT_PRODUCT_NAME ?= "prod-devel"
+
+python __anonymous () {
+    product_name = d.getVar('XT_PRODUCT_NAME', True)
+    folder_name = product_name.replace("-", "_")
+    d.setVar('XT_MANIFEST_FOLDER', folder_name)
+}
+
 SRC_URI = " \
-    repo://github.com/xen-troops/manifests;protocol=https;branch=master;manifest=prod_devel/domd.xml;scmdata=keep \
+    repo://github.com/xen-troops/manifests;protocol=https;branch=master;manifest=${XT_MANIFEST_FOLDER}/domd.xml;scmdata=keep \
 "
 
 SRC_URI_append = " \

--- a/recipes-domu/domu-image-weston/domu-image-weston.bbappend
+++ b/recipes-domu/domu-image-weston/domu-image-weston.bbappend
@@ -4,8 +4,16 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/../../recipes-domx:"
 
 do_configure[depends] += "domd-image-weston:do_domd_install_machine_overrides"
 
+XT_PRODUCT_NAME ?= "prod-devel"
+
+python __anonymous () {
+    product_name = d.getVar('XT_PRODUCT_NAME', True)
+    folder_name = product_name.replace("-", "_")
+    d.setVar('XT_MANIFEST_FOLDER', folder_name)
+}
+
 SRC_URI = " \
-    repo://github.com/xen-troops/manifests;protocol=https;branch=master;manifest=prod_devel/domu.xml;scmdata=keep \
+    repo://github.com/xen-troops/manifests;protocol=https;branch=master;manifest=${XT_MANIFEST_FOLDER}/domu.xml;scmdata=keep \
 "
 
 SRC_URI_append = " \


### PR DESCRIPTION
Add function to transform product name to manifest
folder name substituting hyphen with underscore.

Cherry-picked from gen3-test product with minor alignment (default product name).

Signed-off-by: Iurii Artemenko <iurii_artemenko@epam.com>
Reviewed-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>