### PR TITLE
Fix usage of .dtb for doma

### DIFF
--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas_%.bbappend
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas_%.bbappend
@@ -18,6 +18,11 @@ SRC_URI_append_rcar = " \
     file://0002-Revert-clk-renesas-r8a7796-Remove-clock-that-supplie.patch \
     file://0003-Revert-clk-renesas-r8a7795-Remove-clock-that-supplie.patch \
     file://0004-Revert-clk-renesas-r8a7796-Remove-clock-that-supplie.patch \
+    file://salvator-generic-doma.dts;subdir=git/arch/${ARCH}/boot/dts/renesas \
+"
+
+KERNEL_DEVICETREE_append_rcar = " \
+    renesas/salvator-generic-doma.dtb \
 "
 
 DEPLOYDIR="${XT_DIR_ABS_SHARED_BOOT_DOMD}"
@@ -28,14 +33,12 @@ DEPLOYDIR="${XT_DIR_ABS_SHARED_BOOT_DOMD}"
 SRC_URI_append_salvator-x-h3-4x2g-xt = " \
     file://r8a7795-salvator-x-4x2g-dom0.dts;subdir=git/arch/${ARCH}/boot/dts/renesas \
     file://r8a7795-salvator-x-4x2g-domd.dts;subdir=git/arch/${ARCH}/boot/dts/renesas \
-    file://salvator-generic-doma.dts;subdir=git/arch/${ARCH}/boot/dts/renesas \
     file://r8a7795-salvator-x-4x2g-domu.dts;subdir=git/arch/${ARCH}/boot/dts/renesas \
 "
 
 KERNEL_DEVICETREE_salvator-x-h3-4x2g-xt = " \
     renesas/r8a7795-salvator-x-4x2g-dom0.dtb \
     renesas/r8a7795-salvator-x-4x2g-domd.dtb \
-    renesas/r8a7795-salvator-x-4x2g-doma.dtb \
     renesas/r8a7795-salvator-x-4x2g-domu.dtb \
 "
 
@@ -49,7 +52,6 @@ KERNEL_DEVICETREE_salvator-x-h3-4x2g-xt = " \
 SRC_URI_append_salvator-x-h3-xt = " \
     file://r8a7795-salvator-x-4x2g-dom0.dts;subdir=git/arch/${ARCH}/boot/dts/renesas \
     file://r8a7795-salvator-x-4x2g-domd.dts;subdir=git/arch/${ARCH}/boot/dts/renesas \
-    file://salvator-generic-doma.dts;subdir=git/arch/${ARCH}/boot/dts/renesas \
     file://r8a7795-salvator-x-4x2g-domu.dts;subdir=git/arch/${ARCH}/boot/dts/renesas \
     file://r8a7795-salvator-x-dom0.dts;subdir=git/arch/${ARCH}/boot/dts/renesas \
 "
@@ -57,7 +59,6 @@ SRC_URI_append_salvator-x-h3-xt = " \
 KERNEL_DEVICETREE_salvator-x-h3-xt = " \
     renesas/r8a7795-salvator-x-dom0.dtb \
     renesas/r8a7795-salvator-x-4x2g-domd.dtb \
-    renesas/r8a7795-salvator-x-4x2g-doma.dtb \
     renesas/r8a7795-salvator-x-4x2g-domu.dtb \
 "
 
@@ -68,7 +69,6 @@ SRC_URI_append_salvator-xs-h3-4x2g-xt = " \
     file://r8a7795-salvator-xs-4x2g-dom0.dts;subdir=git/arch/${ARCH}/boot/dts/renesas \
     file://r8a7795-salvator-xs-4x2g-domd.dts;subdir=git/arch/${ARCH}/boot/dts/renesas \
     file://r8a7795-salvator-x-4x2g-domu.dts;subdir=git/arch/${ARCH}/boot/dts/renesas \
-    file://salvator-generic-doma.dts;subdir=git/arch/${ARCH}/boot/dts/renesas \
 "
 
 KERNEL_DEVICETREE_salvator-xs-h3-4x2g-xt = " \
@@ -90,7 +90,6 @@ SRC_URI_append_salvator-xs-h3-2x2g-xt = " \
     file://r8a7795-salvator-xs-4x2g-domd.dts;subdir=git/arch/${ARCH}/boot/dts/renesas \
     file://r8a7795-salvator-x-4x2g-domu.dts;subdir=git/arch/${ARCH}/boot/dts/renesas \
     file://r8a7795-salvator-xs-2x2g-dom0.dts;subdir=git/arch/${ARCH}/boot/dts/renesas \
-    file://salvator-generic-doma.dts;subdir=git/arch/${ARCH}/boot/dts/renesas \
 "
 
 KERNEL_DEVICETREE_salvator-xs-h3-2x2g-xt = " \
@@ -113,7 +112,6 @@ SRC_URI_append_salvator-xs-h3-xt = " \
     file://r8a7795-salvator-xs-4x2g-domd.dts;subdir=git/arch/${ARCH}/boot/dts/renesas \
     file://r8a7795-salvator-x-4x2g-domu.dts;subdir=git/arch/${ARCH}/boot/dts/renesas \
     file://r8a7795-salvator-xs-dom0.dts;subdir=git/arch/${ARCH}/boot/dts/renesas \
-    file://salvator-generic-doma.dts;subdir=git/arch/${ARCH}/boot/dts/renesas \
 "
 
 KERNEL_DEVICETREE_salvator-xs-h3-xt = " \
@@ -132,14 +130,12 @@ KERNEL_DEVICETREE_salvator-xs-h3-xt = " \
 SRC_URI_append_salvator-x-m3-xt = " \
     file://r8a7796-salvator-x-dom0.dts;subdir=git/arch/${ARCH}/boot/dts/renesas \
     file://r8a7796-salvator-x-domd.dts;subdir=git/arch/${ARCH}/boot/dts/renesas \
-    file://salvator-generic-doma.dts;subdir=git/arch/${ARCH}/boot/dts/renesas \
     file://r8a7796-salvator-x-domu.dts;subdir=git/arch/${ARCH}/boot/dts/renesas \
 "
 
 KERNEL_DEVICETREE_salvator-x-m3-xt = " \
     renesas/r8a7796-salvator-x-dom0.dtb \
     renesas/r8a7796-salvator-x-domd.dtb \
-    renesas/r8a7795-salvator-x-4x2g-doma.dtb \
     renesas/r8a7796-salvator-x-domu.dtb \
 "
 


### PR DESCRIPTION
Fix for 7e2d1d1c "Unite *-doma.dts".
DTB was renamed for SRC_URI_XXX, but not for KERNEL_DEVICETREE_XXX.

Also fix erroneously missed DTB for few boards.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>
Signed-off-by: Ruslan Shymkevych <ruslan_shymkevych@epam.com>