### PR TITLE
Remove tag from SRC_URI

### DIFF
--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-extended/libconfig/libconfig_1.5.bbappend
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-extended/libconfig/libconfig_1.5.bbappend
@@ -1,3 +1,3 @@
-SRC_URI = "git://github.com/hyperrealm/libconfig.git;tag=v1.5"
-
+SRC_URI = "git://github.com/hyperrealm/libconfig.git"
+SRCREV = "v1.5"
 S = "${WORKDIR}/git"

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-graphics/wayland/wayland-ivi-extension_2.0.0.bbappend
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-graphics/wayland/wayland-ivi-extension_2.0.0.bbappend
@@ -1,2 +1,2 @@
-BRANCH = "2.0"
-SRC_URI = "git://github.com/GENIVI/${BPN}.git;protocol=http;tag=2.2.0"
+SRC_URI = "git://github.com/GENIVI/${BPN}.git;protocol=http"
+SRCREV = "2.2.0"


### PR DESCRIPTION
wayland-ivi-extension, libconfig:
 Due to build system conflicts we have to set commit hash
 or tag in SRCREV instead of SRC_URI in order
 to use build reconstruction functionality.

Signed-off-by: Iurii Artemenko <iurii_artemenko@epam.com>