### PR TITLE
Fix usage of .dtb for doma

### DIFF
--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas_%.bbappend
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas_%.bbappend
@@ -76,7 +76,6 @@ KERNEL_DEVICETREE_salvator-xs-h3-4x2g-xt = " \
     renesas/r8a7795-salvator-xs-4x2g-dom0.dtb \
     renesas/r8a7795-salvator-xs-4x2g-domd.dtb \
     renesas/r8a7795-salvator-x-4x2g-domu.dtb \
-    renesas/r8a7795-salvator-xs-doma.dtb \
 "
 
 ##############################################################################
@@ -98,7 +97,6 @@ KERNEL_DEVICETREE_salvator-xs-h3-2x2g-xt = " \
     renesas/r8a7795-salvator-xs-4x2g-domd.dtb \
     renesas/r8a7795-salvator-x-4x2g-domu.dtb \
     renesas/r8a7795-salvator-xs-2x2g-dom0.dtb \
-    renesas/r8a7795-salvator-xs-doma.dtb \
 "
 
 ##############################################################################
@@ -120,7 +118,6 @@ KERNEL_DEVICETREE_salvator-xs-h3-xt = " \
     renesas/r8a7795-salvator-xs-4x2g-domd.dtb \
     renesas/r8a7795-salvator-x-4x2g-domu.dtb \
     renesas/r8a7795-salvator-xs-dom0.dtb \
-    renesas/r8a7795-salvator-xs-doma.dtb \
 "
 
 ##############################################################################


### PR DESCRIPTION
Remove missed DTB for Salvator-XS boards.
Fixes: 00585da ("Unite *-doma.dts")

Signed-off-by: Iurii Artemenko <iurii_artemenko@epam.com>