### PR TITLE
Xen 4.12rc migration

### DIFF
--- a/inc/xen-version.inc
+++ b/inc/xen-version.inc
@@ -3,6 +3,6 @@
 # Following inc file defines XEN version and needed glue info to get it
 # built with the current yocto version
 ################################################################################
-require ../meta-xt-images-domx/recipes-extended/xen/xen-4.10-rocko.inc
+require ../meta-xt-images-domx/recipes-extended/xen/xen-4.12-rocko.inc
 
 SRC_URI = "git://github.com/xen-troops/xen.git;protocol=https;branch=master"

--- a/recipes-dom0/dom0-image-thin-initramfs/dom0-image-thin-initramfs.bbappend
+++ b/recipes-dom0/dom0-image-thin-initramfs/dom0-image-thin-initramfs.bbappend
@@ -54,7 +54,7 @@ add_to_local_conf() {
     # direct call to getty with hvc0 is installed into inittab by meta-viltualization.
     base_update_conf_value ${local_conf} SERIAL_CONSOLE ""
 
-    base_update_conf_value ${local_conf} PREFERRED_VERSION_xen "4.10.0+git\%"
+    base_update_conf_value ${local_conf} PREFERRED_VERSION_xen "4.12.0+git\%"
 
     base_update_conf_value ${local_conf} XT_GUESTS_INSTALL "${XT_GUESTS_INSTALL}"
 }

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/xen/files/0001-libxl-Add-DTB-compatible-list-to-config-file.patch
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/xen/files/0001-libxl-Add-DTB-compatible-list-to-config-file.patch
@@ -1,6 +1,6 @@
-From ecf48cf35ffa529614c8b14785f49f4aa0742a10 Mon Sep 17 00:00:00 2001
+From 8561720d294b4b19934b20cec1daf2a6e12913ea Mon Sep 17 00:00:00 2001
 From: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>
-Date: Thu, 5 Oct 2017 13:43:47 +0300
+Date: Wed, 4 Apr 2018 20:15:50 +0300
 Subject: [PATCH 1/2] libxl: Add DTB compatible list to config file
 
 Some platforms need more compatible property values in device
@@ -18,10 +18,10 @@ Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>
  3 files changed, 42 insertions(+), 8 deletions(-)
 
 diff --git a/tools/libxl/libxl_arm.c b/tools/libxl/libxl_arm.c
-index 04ff60c..d0a2ebe 100644
+index 022feb9..a56b062 100644
 --- a/tools/libxl/libxl_arm.c
 +++ b/tools/libxl/libxl_arm.c
-@@ -287,20 +287,46 @@ static int fdt_property_regs(libxl__gc *gc, void *fdt,
+@@ -265,20 +265,46 @@ static int fdt_property_regs(libxl__gc *gc, void *fdt,
  
  static int make_root_properties(libxl__gc *gc,
                                  const libxl_version_info *vers,
@@ -74,21 +74,21 @@ index 04ff60c..d0a2ebe 100644
 +    res = fdt_property(fdt, "compatible", compat, sz);
      if (res) return res;
  
-     res = fdt_property_cell(fdt, "interrupt-parent", PHANDLE_GIC);
-@@ -930,7 +956,7 @@ next_resize:
+     res = fdt_property_cell(fdt, "interrupt-parent", GUEST_PHANDLE_GIC);
+@@ -899,7 +925,7 @@ next_resize:
  
          FDT( fdt_begin_node(fdt, "") );
  
 -        FDT( make_root_properties(gc, vers, fdt) );
 +        FDT( make_root_properties(gc, vers, fdt, info) );
-         FDT( make_chosen_node(gc, fdt, !!dom->ramdisk_blob, state, info) );
+         FDT( make_chosen_node(gc, fdt, !!dom->modules[0].blob, state, info) );
          FDT( make_cpus_node(gc, fdt, info->max_vcpus, ainfo) );
          FDT( make_psci_node(gc, fdt) );
 diff --git a/tools/libxl/libxl_types.idl b/tools/libxl/libxl_types.idl
-index 76ea36b..368dcff 100644
+index ea1d79f..c50fe61 100644
 --- a/tools/libxl/libxl_types.idl
 +++ b/tools/libxl/libxl_types.idl
-@@ -521,6 +521,7 @@ libxl_domain_build_info = Struct("domain_build_info",[
+@@ -527,6 +527,7 @@ libxl_domain_build_info = Struct("domain_build_info",[
      # Note that the partial device tree should avoid to use the phandle
      # 65000 which is reserved by the toolstack.
      ("device_tree",      string),
@@ -97,10 +97,10 @@ index 76ea36b..368dcff 100644
      ("bootloader",       string),
      ("bootloader_args",  libxl_string_list),
 diff --git a/tools/xl/xl_parse.c b/tools/xl/xl_parse.c
-index 663449c..357b2f5 100644
+index ce19d24..6110d2e 100644
 --- a/tools/xl/xl_parse.c
 +++ b/tools/xl/xl_parse.c
-@@ -2331,6 +2331,13 @@ skip_vfb:
+@@ -2385,6 +2385,13 @@ skip_vfb:
          }
      }
  

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/xen/files/0002-libxl-Add-DTB-passthrough-nodes-list.patch
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/xen/files/0002-libxl-Add-DTB-passthrough-nodes-list.patch
@@ -1,6 +1,6 @@
-From 7e43cfc9b76cef7205831c108739f4c1aa8db69b Mon Sep 17 00:00:00 2001
+From 11126b1e1d46ea629283eb55e077e94bf6ef6215 Mon Sep 17 00:00:00 2001
 From: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>
-Date: Thu, 5 Oct 2017 14:51:07 +0300
+Date: Wed, 4 Apr 2018 20:22:27 +0300
 Subject: [PATCH 2/2] libxl: Add DTB passthrough nodes list
 
 Some platforms need more nodes from partial device tree in
@@ -20,10 +20,10 @@ Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>
  3 files changed, 24 insertions(+), 4 deletions(-)
 
 diff --git a/tools/libxl/libxl_arm.c b/tools/libxl/libxl_arm.c
-index d0a2ebe..db83eb7 100644
+index a56b062..a38b081 100644
 --- a/tools/libxl/libxl_arm.c
 +++ b/tools/libxl/libxl_arm.c
-@@ -833,9 +833,10 @@ static int copy_node_by_path(libxl__gc *gc, const char *path,
+@@ -804,9 +804,10 @@ static int copy_node_by_path(libxl__gc *gc, const char *path,
   *  - /passthrough node
   *  - /aliases node
   */
@@ -36,7 +36,7 @@ index d0a2ebe..db83eb7 100644
  
      r = copy_node_by_path(gc, "/passthrough", fdt, pfdt);
      if (r < 0) {
-@@ -849,6 +850,16 @@ static int copy_partial_fdt(libxl__gc *gc, void *fdt, void *pfdt)
+@@ -820,6 +821,16 @@ static int copy_partial_fdt(libxl__gc *gc, void *fdt, void *pfdt)
          return r;
      }
  
@@ -53,7 +53,7 @@ index d0a2ebe..db83eb7 100644
      return 0;
  }
  
-@@ -861,7 +872,8 @@ static int check_partial_fdt(libxl__gc *gc, void *fdt, size_t size)
+@@ -832,7 +843,8 @@ static int check_partial_fdt(libxl__gc *gc, void *fdt, size_t size)
      return ERROR_FAIL;
  }
  
@@ -63,7 +63,7 @@ index d0a2ebe..db83eb7 100644
  {
      /*
       * We should never be here when the partial device tree is not
-@@ -986,7 +998,7 @@ next_resize:
+@@ -955,7 +967,7 @@ next_resize:
              FDT( make_vpl011_uart_node(gc, fdt, ainfo, dom) );
  
          if (pfdt)
@@ -73,10 +73,10 @@ index d0a2ebe..db83eb7 100644
          FDT( fdt_end_node(fdt) );
  
 diff --git a/tools/libxl/libxl_types.idl b/tools/libxl/libxl_types.idl
-index 368dcff..ec4217a 100644
+index c50fe61..843ff6c 100644
 --- a/tools/libxl/libxl_types.idl
 +++ b/tools/libxl/libxl_types.idl
-@@ -522,6 +522,7 @@ libxl_domain_build_info = Struct("domain_build_info",[
+@@ -528,6 +528,7 @@ libxl_domain_build_info = Struct("domain_build_info",[
      # 65000 which is reserved by the toolstack.
      ("device_tree",      string),
      ("dt_compatible",    libxl_string_list),
@@ -85,10 +85,10 @@ index 368dcff..ec4217a 100644
      ("bootloader",       string),
      ("bootloader_args",  libxl_string_list),
 diff --git a/tools/xl/xl_parse.c b/tools/xl/xl_parse.c
-index 357b2f5..abfc094 100644
+index 6110d2e..56020bd 100644
 --- a/tools/xl/xl_parse.c
 +++ b/tools/xl/xl_parse.c
-@@ -2338,6 +2338,13 @@ skip_vfb:
+@@ -2392,6 +2392,13 @@ skip_vfb:
              exit(-ERROR_FAIL);
      }
  

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/xen/xen_git.bbappend
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/xen/xen_git.bbappend
@@ -20,7 +20,7 @@ PACKAGECONFIG[xsm] = ""
 do_install_append() {
     # FIXME: we do not want XSM, but Xen still installs it making
     # package QA Issue to raise for files installed
-    rm ${D}/boot/xenpolicy-${XEN_REL}.0 || true
+    rm ${D}/boot/xenpolicy-${XEN_REL}* || true
 
     # FIXME: this is to fix run-time issues
     # "libxl__lock_domain_userdata: Domain 0:cannot open lockfile /var/lib/xen/"

--- a/recipes-domd/domd-image-weston/domd-image-weston.bbappend
+++ b/recipes-domd/domd-image-weston/domd-image-weston.bbappend
@@ -65,7 +65,7 @@ configure_versions_rcar() {
     local local_conf="${S}/build/conf/local.conf"
 
     cd ${S}
-    base_update_conf_value ${local_conf} PREFERRED_VERSION_xen "4.10.0+git\%"
+    base_update_conf_value ${local_conf} PREFERRED_VERSION_xen "4.12.0+git\%"
     base_update_conf_value ${local_conf} PREFERRED_VERSION_u-boot_rcar "v2015.04\%"
     if [ -z ${XT_RCAR_EVAPROPRIETARY_DIR} ];then
         base_update_conf_value ${local_conf} PREFERRED_PROVIDER_gles-user-module "gles-user-module"

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-extended/xen/xen_git.bbappend
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-extended/xen/xen_git.bbappend
@@ -23,7 +23,7 @@ SRC_URI_append_r8a7796 = " \
 # Generic
 ################################################################################
 
-FLASK_POLICY_FILE = "xenpolicy-${XEN_REL}.0"
+FLASK_POLICY_FILE = "xenpolicy-${XEN_REL}.0-rc"
 FILES_${PN}-flask = " \
     /boot/${FLASK_POLICY_FILE} \
 "

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas/xen-chosen.dtsi
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas/xen-chosen.dtsi
@@ -11,7 +11,7 @@
 
 / {
 	chosen {
-		bootargs = "dom0_mem=256M console=dtuart dtuart=serial0 dom0_max_vcpus=4 bootscrub=0 loglvl=all cpufreq=none sched=credit2 sched_ratelimit_us=100";
+		bootargs = "dom0_mem=256M console=dtuart dtuart=serial0 dom0_max_vcpus=4 bootscrub=0 loglvl=all sched_ratelimit_us=100";
 		xen,dom0-bootargs = "console=hvc0 ignore_loglevel";
 		/delete-property/stdout-path;
 		modules {

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas/xen-chosen.dtsi
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas/xen-chosen.dtsi
@@ -11,7 +11,7 @@
 
 / {
 	chosen {
-		bootargs = "dom0_mem=256M console=dtuart dtuart=serial0 dom0_max_vcpus=4 bootscrub=0 loglvl=all sched_ratelimit_us=100";
+		bootargs = "dom0_mem=256M console=dtuart dtuart=serial0 dom0_max_vcpus=4 bootscrub=0 loglvl=all sched_ratelimit_us=100 hmp-unsafe=true";
 		xen,dom0-bootargs = "console=hvc0 ignore_loglevel";
 		/delete-property/stdout-path;
 		modules {


### PR DESCRIPTION
Please note, here we have still adopted xen_git.bbappend from meta-xt-images. Switching to .inc files should be done as a separate task.