### PR TITLE
domd:weston: promote weston sources revision

### DIFF
--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-graphics/wayland/weston_%.bbappend
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-graphics/wayland/weston_%.bbappend
@@ -17,6 +17,8 @@ SRC_URI_append = "file://weston-seats.rules \
                   file://0001-v4l2-renderer-Release-dma-buf-when-attaching-null-bu.patch \
 "
 
+SRCREV = "84709ddcbf1e94edae96038f530e9ddd855f707f"
+
 FILES_${PN} += " \
     ${sysconfdir}/udev/rules.d/weston-seats.rules \
 "


### PR DESCRIPTION
In order to adopt the latest fix for dma-buf release, we have to use an
appropriate code base version. So promote weston's SRCREV to the current
HEAD of the taken branch.

Signed-off-by: Andrii Anisov <andrii_anisov@epam.com>