### PR TITLE
op-tee patch set: doma.cfg: Specify android's device tree

### DIFF
--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/doma-salvator-generic.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/doma-salvator-generic.cfg
@@ -32,7 +32,7 @@ disk = [
 ]
 
 # Kernel command line options
-extra = "ip=dhcp root=/dev/xvda1 androidboot.hardware=xenvm skip_initramfs init=/init ro rootwait console=hvc0 cma=256M@1-2G printk.devkmsg=on androidboot.selinux=permissive pvrsrvkm.DriverMode=1"
+extra = "ip=dhcp root=/dev/xvda1 androidboot.hardware=xenvm skip_initramfs init=/init ro rootwait console=hvc0 cma=256M@1-2G printk.devkmsg=on androidboot.selinux=permissive pvrsrvkm.DriverMode=1 androidboot.android_dt_dir=/proc/device-tree/firmware#1/android/"
 
 # Initial memory allocation (MB)
 memory = 2240
@@ -66,3 +66,5 @@ vsnd = [[ 'card, backend=DomD, buffer-size=65536, short-name=VCard, long-name=Vi
        ]]
 
 on_crash = 'preserve'
+
+tee = 'native'

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/doma-salvator-x-h3-4x2g.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/doma-salvator-x-h3-4x2g.cfg
@@ -36,7 +36,7 @@ disk = [
 ]
 
 # Kernel command line options
-extra = "ip=dhcp root=/dev/xvda1 androidboot.hardware=xenvm skip_initramfs init=/init ro rootwait console=hvc0 cma=256M@1-2G printk.devkmsg=on androidboot.selinux=permissive pvrsrvkm.DriverMode=1"
+extra = "ip=dhcp root=/dev/xvda1 androidboot.hardware=xenvm skip_initramfs init=/init ro rootwait console=hvc0 cma=256M@1-2G printk.devkmsg=on androidboot.selinux=permissive pvrsrvkm.DriverMode=1 androidboot.android_dt_dir=/proc/device-tree/firmware#1/android/"
 
 # Initial memory allocation (MB)
 memory = 6112
@@ -70,3 +70,5 @@ vsnd = [[ 'card, backend=DomD, buffer-size=65536, short-name=VCard, long-name=Vi
        ]]
 
 on_crash = 'preserve'
+
+tee = 'native'


### PR DESCRIPTION
Android share one device node with op-tee. This results in inability
of Android to properly load device tree. So we have to direct android
to proper location of it's device tree.

Signed-off-by: Ruslan Shymkevych <ruslan_shymkevych@epam.com>