### PR TITLE
Add missed interrupt-controller mem range to m3 domain cfg file

### DIFF
--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domd-salvator-x-m3.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domd-salvator-x-m3.cfg
@@ -287,6 +287,8 @@ iomem = [
     "fff00,1",
 #system-controller@e6180000
     "e6180,1",
+#interrupt-controller@e61c0000
+    "e61c0,1",
 #pwm@e6e31000
     "e6e31,1",
 #pwm@e6e32000


### PR DESCRIPTION
With i2c_dvfs being assigned to domd, interrupt-controller@e61c0000
mem range must be accessible here as well.

Signed-off-by: Oleksandr Tyshchenko <oleksandr_tyshchenko@epam.com>