### PR TITLE
doma: Provide 6GB to doma for salvator-x-h3-4x2g machine

### DIFF
--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/doma-salvator-x-h3-4x2g.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/doma-salvator-x-h3-4x2g.cfg
@@ -39,7 +39,7 @@ disk = [
 extra = "ip=dhcp root=/dev/xvda1 androidboot.hardware=xenvm skip_initramfs init=/init ro rootwait console=hvc0 cma=256M@1-2G printk.devkmsg=on androidboot.selinux=permissive pvrsrvkm.DriverMode=1"
 
 # Initial memory allocation (MB)
-memory = 2240
+memory = 6112
 
 # Number of VCPUS
 vcpus = 4


### PR DESCRIPTION
Doma memory was reduced due to issue:
vdispl vdispl-0: DMA: Out of SW-IOMMU space for 1048576 bytes
pvrsrvkm fd000000.gsx: DMA: Out of SW-IOMMU space for 1048576 bytes
Appropriate fixes were merged an we can place back 6GB.

Signed-off-by: Andrii Chepurnyi <andrii_chepurnyi@epam.com>