### PR TITLE
domd: remove telemetry-emulator from IMAGE_INSTALL_append

### DIFF
--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-graphics/images/core-image-weston.bbappend
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-graphics/images/core-image-weston.bbappend
@@ -10,7 +10,6 @@ IMAGE_INSTALL_append = " \
     kmscube \
     optee-os \
     displaymanager \
-    telemetry-emulator \
     aos-vis \
     ${@bb.utils.contains('AOS_VIS_PLUGINS', 'telemetryemulatoradapter', 'telemetry-emulator', '', d)} \
 "


### PR DESCRIPTION
telemetry-emulator is added conditionally and should be removed from
the append list.

Signed-off-by: Oleksandr Grytsov <oleksandr_grytsov@epam.com>