### PR TITLE
Remove kernel prebuilt from INSTALL.txt

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -7,7 +7,7 @@ Prerequisites:
                     gnupg flex bison gperf build-essential zip curl zlib1g-dev \
                     gcc-multilib g++-multilib libc6-dev-i386 lib32ncurses5-dev \
                     x11proto-core-dev libx11-dev lib32z-dev ccache libgl1-mesa-dev \
-                    libxml2-utils xsltproc unzip -y
+                    libxml2-utils xsltproc unzip python-clang-5.0 -y
 2. Download and install Google repo: https://source.android.com/setup/build/downloading#installing-repo
 3. Checked with Python v 2.7.12, but other should also work
 

--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -106,6 +106,7 @@ I.e. you should have such directories structure:
         │   ├── libIMGegl.so
         │   ├── libPVRScopeServices.so
         │   ├── libsrv_um.so
+        │   ├── libtqvalidate.so
         │   └── libusc.so
         └── lib64
             ├── egl
@@ -119,6 +120,7 @@ I.e. you should have such directories structure:
             ├── libIMGegl.so
             ├── libPVRScopeServices.so
             ├── libsrv_um.so
+            ├── libtqvalidate.so
             └── libusc.so
 
 

--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -77,9 +77,6 @@ DomA prebuilts:
 Unpack it to some "..PREBUILTS_FOLDER_PATH.."
 I.e. you should have such directories structure:
 "..ANDROID_PREBUILTS_FOLDER_PATH.."
-├── kernel
-│   ├── Image
-│   └── vmlinux
 ├── pvr-km
 │   └── pvrsrvkm.ko
 └── pvr-um


### PR DESCRIPTION
TARGET_PREBUILT_KERNEL is not obligatory now,
becuse kernel is in opensource and it not set in
meta-xt-images after patch
"doma: Do not propagate TARGET_PREBUILT_KERNEL".

Signed-off-by: Andrii Chepurnyi <andrii_chepurnyi@epam.com>