### PR TITLE
Update INSTALL.txt with AOS VIS packages

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -141,6 +141,10 @@ For example (Salvator-XS case),
 
 ln -s rcar-proprietary-graphic-salvator-x-h3-4x2g-xt-domd.tar.gz rcar-proprietary-graphic-salvator-xs-h3-4x2g-xt-domd.tar.gz
 
+AOS VIS prebuilts:
+
+AOS_VIS_PACKAGE_DIR should points to the directory with: aos-vis_git-r0_aarch64.ipk, ca-certificates_20170717-r0_all.ipk
+
 
 5. Run the build script for current stable release:
 


### PR DESCRIPTION
In case of prod-devl build, AOS VIS can be installed from a
prebuilt package. AOS_VIS_PACKAGE_DIR should points to directory
with aos-vis_git-r0_aarch64.ipk, ca-certificates_20170717-r0_all.ipk.

Signed-off-by: Andrii Chepurnyi <andrii_chepurnyi@epam.com>