### PR TITLE
domd: Provide DM config for kingfisher_r8a7795 board

### DIFF
--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-extended/guest-addons/guest-addons.bb
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-extended/guest-addons/guest-addons.bb
@@ -88,6 +88,7 @@ DM_CONFIG_salvator-xs-h3-4x2g-xt = "dm-salvator-x-h3.cfg"
 DM_CONFIG_salvator-xs-h3-2x2g-xt = "dm-salvator-x-h3.cfg"
 DM_CONFIG_salvator-x-h3-4x2g-xt = "dm-salvator-x-h3.cfg"
 DM_CONFIG_ulcb = "dm-ulcb.cfg"
+DM_CONFIG_kingfisher_r8a7795 = "dm-salvator-x-h3.cfg"
 
 do_install() {
     install -d ${D}${base_prefix}${XT_DIR_ABS_ROOTFS_SCRIPTS}


### PR DESCRIPTION
All {H|M}3ULCB boards have single display connector.
Kingfisher has also single display connector.
It's appeared that Salvator-x-h3 config file
works well with kingfisher_r8a7795 board.
Tested both display outputs with DomD and DomA.

Signed-off-by: Viktor Mitin <viktor_mitin@epam.com>