### PR TITLE
domd: supersede 'wireless-tools' by 'iw' in rootfs image

### DIFF
--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-graphics/images/core-image-weston.bbappend
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-graphics/images/core-image-weston.bbappend
@@ -37,6 +37,14 @@ IMAGE_INSTALL_remove = " \
     packagegroup-graphics-renesas-proprietary \
 "
 
+IMAGE_INSTALL_append_kingfisher = " \
+    iw \
+"
+
+IMAGE_INSTALL_remove_kingfisher = " \
+    wireless-tools \
+"
+
 CORE_IMAGE_BASE_INSTALL_remove += "gtk+3-demo clutter-1.0-examples"
 
 populate_vmlinux () {


### PR DESCRIPTION
Currently 'wireless-tools' which is needed for
h3ulcb-4x2g-kf-xt machine became obsolete so,
supersed it by 'iw' in final rootfs image.

Signed-off-by: Iurii Artemenko <iurii_artemenko@epam.com>