### PR TITLE
Remove pcm3168a from device tree

### DIFF
--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domd-h3ulcb-4x2g-kf.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domd-h3ulcb-4x2g-kf.cfg
@@ -91,7 +91,6 @@ dt_passthrough_nodes = [
     "/regulator@13",
     "/kim",
     "/btwilink",
-    "/sound@0",
     "/sound@1",
     "/sound@2",
     "/sound@3",


### PR DESCRIPTION
Remove pcm3168a from device tree.
Add card name provided by meta-rcar-gen3-adas to configuration file
used by alsactl.

Signed-off-by: Ruslan Shymkevych <ruslan_shymkevych@epam.com>