### PR TITLE
dom0/domd: enhance editing experience in domain shell

### DIFF
--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-core/base-files/base-files_%.bbappend
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-core/base-files/base-files_%.bbappend
@@ -1,0 +1,4 @@
+do_install_append () {
+	echo "shopt -s checkwinsize" >> ${D}${sysconfdir}/profile
+	echo "resize 1> /dev/null" >> ${D}${sysconfdir}/profile
+}

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-core/base-files/base-files_%.bbappend
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-core/base-files/base-files_%.bbappend
@@ -5,4 +5,6 @@ hostname .= "-domd"
 
 do_install_append () {
 	sed -i '/PATH="/a PATH="$PATH:${base_prefix}${XT_DIR_ABS_ROOTFS_SCRIPTS}"' ${D}${sysconfdir}/profile
+	echo "shopt -s checkwinsize" >> ${D}${sysconfdir}/profile
+	echo "resize 1> /dev/null" >> ${D}${sysconfdir}/profile
 }


### PR DESCRIPTION
"shopt -s checkwinsize" - will change the behaviour of command
placement in shell input. I.e. will not wrap input, but
continue it from the next line if it too big.

"resize" - set environment and terminal settings to current
xterm window size

Signed-off-by: Andrii Chepurnyi <andrii_chepurnyi@epam.com>