### PR TITLE
mk_sdcard_image: Check number of found images

### DIFF
--- a/doc/mk_sdcard_image.sh
+++ b/doc/mk_sdcard_image.sh
@@ -342,6 +342,11 @@ unpack_dom0()
 	echo "Xen policy is at $xenpolicy"
 	echo "Xen image is at $xenuImage"
 
+	if [ $(echo "$Image" | wc -w) -gt 1 ]; then
+		echo "Error: Too many kernel images were found."
+		exit 1
+	fi
+
 	mount_part $loop_base $part $MOUNT_POINT
 
 	sudo mkdir "${MOUNT_POINT}/boot" || true


### PR DESCRIPTION
If dom0/initramfs is unpacked into dom0 subfolder, 'find' will return
all found kernel images and incorrect kernel will be used as dom0 kernel.

This patch prevents such error.

Signed-off-by: Ruslan Shymkevych <ruslan_shymkevych@epam.com>