### PR TITLE
Update u-boot-env.txt with changes from gen3-test

### DIFF
--- a/doc/u-boot-env.txt
+++ b/doc/u-boot-env.txt
@@ -1,41 +1,59 @@
 Boot storage device setting
 ===================================
-In order to make it possible to boot from various storage devices,
-e.g. SD, eMMC etc, a some settings need to be done in the environment:
-setenv boot_dev=<dev-name>, where <dev-name> is the name of the
-storage device without "/dev/", e.g.
-"setenv boot_dev memcblk0" to boot from eMMC
 
-setenv boot_dev mmcblk1
-setenv set_boot_dev 'fdt addr 0x48000000; fdt resize; fdt mknode / boot_dev; fdt set /boot_dev device ${boot_dev}'
+Boot device is selected by setting 'bootcmd' variable.
+Possible settings for available boot devices are:
+emmc: setenv bootcmd run bootcmd_emmc
+sd0:  setenv bootcmd run bootcmd_mmc0
+sd3:  setenv bootcmd run bootcmd_mmc1
+net:  setenv bootcmd run bootcmd_tftp
+
+This hints can be stored on board if you set variables 'z_bootcmd_help_*'.
+See section 'Reminders for bootcmd usage' below.
 
 Salvator-X(S)/H3ULCB/M3ULCB
 ===================================
 
 setenv bootdelay 3
 setenv baudrate 115200
+setenv bootargs
+setenv ethact ravb
+setenv ipaddr 192.168.1.10
+setenv serverip 192.168.1.100
+setenv ethaddr 2E:09:0A:00:A0:41
+
+N.B. Either do not set MAC address (should be shipped with u-boot environment already) or put any other MAC address
+which will not make conflicts on your network. See sticker on your board.
+
+
+for tftp boot:
+===================================
+
+setenv bootcmd run bootcmd_tftp
+setenv bootcmd_tftp 'run tftp_xen_load; run tftp_dtb_load; run tftp_kernel_load; run tftp_xenpolicy_load; run tftp_initramfs_load; bootm 0x48080000 0x76000000 0x48000000'
+setenv tftp_dtb_load 'tftp 0x48000000 dom0.dtb; fdt addr 0x48000000; fdt resize; fdt mknode / boot_dev; fdt set /boot_dev device nfs'
+setenv tftp_initramfs_load tftp 0x76000000 uInitramfs
+setenv tftp_kernel_load tftp 0x7a000000 Image
+setenv tftp_xen_load tftp 0x48080000 xen-uImage
+setenv tftp_xenpolicy_load tftp 0x7c000000 xenpolicy
 
 for SD0 card boot:
 ===================================
 
-setenv boot_dev mmcblk1
-setenv bootcmd run bootcmd_xen_mmc0
-setenv bootcmd_xen_mmc0 'run mmc0_xen_load; run mmc0_dtb_load; run mmc0_kernel_load; run mmc0_xenpolicy_load; run mmc0_initramfs_load; bootm 0x48080000 0x76000000 0x48000000'
-
-setenv mmc0_dtb_load 'ext2load mmc 0:1 0x48000000 /boot/dom0.dtb; run set_boot_dev'
+setenv bootcmd run bootcmd_mmc0
+setenv bootcmd_mmc0 'run mmc0_xen_load; run mmc0_dtb_load; run mmc0_kernel_load; run mmc0_xenpolicy_load; run mmc0_initramfs_load; bootm 0x48080000 0x76000000 0x48000000'
+setenv mmc0_dtb_load 'ext2load mmc 0:1 0x48000000 /boot/dom0.dtb; fdt addr 0x48000000; fdt resize; fdt mknode / boot_dev; fdt set /boot_dev device mmcblk1'
 setenv mmc0_initramfs_load ext2load mmc 0:1 0x76000000 /boot/uInitramfs
 setenv mmc0_kernel_load ext2load mmc 0:1 0x7a000000 /boot/Image
 setenv mmc0_xen_load ext2load mmc 0:1 0x48080000 /boot/xen-uImage
 setenv mmc0_xenpolicy_load ext2load mmc 0:1 0x7c000000 /boot/xenpolicy
 
-for SD1 card boot (Salvator-X(S) only):
+for SD3 card boot (Salvator-X(S) only):
 ===================================
 
-setenv boot_dev mmcblk2
-setenv bootcmd run bootcmd_xen_mmc1
-setenv bootcmd_xen_mmc1 'run mmc1_xen_load; run mmc1_dtb_load; run mmc1_kernel_load; run mmc1_xenpolicy_load; run mmc1_initramfs_load; bootm 0x48080000 0x76000000 0x48000000'
-
-setenv mmc1_dtb_load 'ext2load mmc 2:1 0x48000000 /boot/dom0.dtb; run set_boot_dev'
+setenv bootcmd run bootcmd_mmc1
+setenv bootcmd_mmc1 'run mmc1_xen_load; run mmc1_dtb_load; run mmc1_kernel_load; run mmc1_xenpolicy_load; run mmc1_initramfs_load; bootm 0x48080000 0x76000000 0x48000000'
+setenv mmc1_dtb_load 'ext2load mmc 2:1 0x48000000 /boot/dom0.dtb; fdt addr 0x48000000; fdt resize; fdt mknode / boot_dev; fdt set /boot_dev device mmcblk2'
 setenv mmc1_initramfs_load ext2load mmc 2:1 0x76000000 /boot/uInitramfs
 setenv mmc1_kernel_load ext2load mmc 2:1 0x7a000000 /boot/Image
 setenv mmc1_xen_load ext2load mmc 2:1 0x48080000 /boot/xen-uImage
@@ -44,44 +62,48 @@ setenv mmc1_xenpolicy_load ext2load mmc 2:1 0x7c000000 /boot/xenpolicy
 for eMMC boot:
 ===================================
 
-setenv boot_dev mmcblk0
-setenv bootcmd run bootcmd_xen_emmc
-setenv bootcmd_xen_emmc 'run emmc_xen_load; run emmc_dtb_load; run emmc_kernel_load; run emmc_xenpolicy_load; run emmc_initramfs_load; bootm 0x48080000 0x76000000 0x48000000'
-
-setenv emmc_dtb_load 'ext2load mmc 1:1 0x48000000 /boot/dom0.dtb; run set_boot_dev'
+setenv bootcmd run bootcmd_emmc
+setenv bootcmd_emmc 'run emmc_xen_load; run emmc_dtb_load; run emmc_kernel_load; run emmc_xenpolicy_load; run emmc_initramfs_load; bootm 0x48080000 0x76000000 0x48000000'
+setenv emmc_dtb_load 'ext2load mmc 1:1 0x48000000 /boot/dom0.dtb; fdt addr 0x48000000; fdt resize; fdt mknode / boot_dev; fdt set /boot_dev device mmcblk0'
 setenv emmc_initramfs_load ext2load mmc 1:1 0x76000000 /boot/uInitramfs
 setenv emmc_kernel_load ext2load mmc 1:1 0x7a000000 /boot/Image
 setenv emmc_xen_load ext2load mmc 1:1 0x48080000 /boot/xen-uImage
 setenv emmc_xenpolicy_load ext2load mmc 1:1 0x7c000000 /boot/xenpolicy
 
+Reminders for bootcmd usage
+===================================
+
+These variables have no practical use, but are reminders supposed to make easier usage of bootcmd.
+Prefix 'z_' is added intentionaly, so these lines will be easy to identify as last in list after 'printenv'.
+
+setenv z_bootcmd_help_1 'emmc: setenv bootcmd run bootcmd_emmc'
+setenv z_bootcmd_help_2 'sd0:  setenv bootcmd run bootcmd_mmc0'
+setenv z_bootcmd_help_3 'sd3:  setenv bootcmd run bootcmd_mmc1'
+setenv z_bootcmd_help_4 'net:  setenv bootcmd run bootcmd_tftp'
+
 Bootloaders from eMMC:
 ===================================
+
 In case of boot SoC from the eMMC boot partition 1 (50MHz x8 bus width mode) instead of Serial Flash,
 we have an ability to flash bootloader image(s) right here in U-Boot (images must be in raw binary format).
 Partitions and offsets the images need to be flashed to were retrieved here:
 https://github.com/renesas-rcar/flash_writer/blob/rcar_gen3/docs/application-note.md#348-write-to-the-s-record-format-images-to-the-emmc
 
-setenv flash_bootparam_sa0 'tftp 0x48000000 bootparam_sa0.bin; mmc dev 1 1; mmc write 0x48000000 0x0 0x1E;'
+Pay attention that tee.bin from the daily build is provided in two forms: with a prepended header and raw binary.
+In the command below, we use raw form which name starts with 'tee_raw-*'.
+File without '_raw' in the name can not be used for flashing as described below.
+In case your build does not contain 'raw' tee binary, you can remove the header manualy.
+The header can be recognized by the presence of 'OPTE' in the first four characters of the file.
+In order to remove it:
+dd bs=28 skip=1 if=<your_tee_with_header.bin> of=tee.bin
+
 setenv flash_bl2 'tftp 0x48000000 bl2.bin; mmc dev 1 1; mmc write 0x48000000 0x1E 0x162;'
-setenv flash_cert_header_sa6 'tftp 0x48000000 cert_header_sa6_emmc.bin; mmc dev 1 1; mmc write 0x48000000 0x180 0x80;'
 setenv flash_bl31 'tftp 0x48000000 bl31.bin; mmc dev 1 1; mmc write 0x48000000 0x200 0xE00;'
+setenv flash_bootparam_sa0 'tftp 0x48000000 bootparam_sa0.bin; mmc dev 1 1; mmc write 0x48000000 0x0 0x1E;'
+setenv flash_cert_header_sa6 'tftp 0x48000000 cert_header_sa6_emmc.bin; mmc dev 1 1; mmc write 0x48000000 0x180 0x80;'
 setenv flash_tee 'tftp 0x48000000 tee.bin; mmc dev 1 1; mmc write 0x48000000 0x1000 0x400;'
 setenv flash_u_boot 'tftp 0x48000000 u-boot.bin; mmc dev 1 2; mmc write 0x48000000 0x0 0x800;'
-setenv flash_loaders 'run flash_bootparam_sa0; run flash_bl2; run flash_cert_header_sa6; run flash_bl31; run flash_tee; run flash_u_boot;'
-
-setenv ethact ravb
-
-N.B. Either do not set MAC address (should be shipped
-with u-boot environment already) or put any other MAC address
-which will not make conflicts on your network
-(see stickers on your board):
-
-setenv ethaddr 2E:09:0A:00:A0:41
-
-setenv ipaddr 192.168.1.10
-setenv serverip 192.168.1.100
-
-setenv bootargs
+setenv flash_z_loaders 'run flash_bootparam_sa0; run flash_bl2; run flash_cert_header_sa6; run flash_bl31; run flash_tee; run flash_u_boot;'
 
 saveenv
 


### PR DESCRIPTION
Combined commits from gen3-test with minor changes:
d578d099 Add instruction how to remove header from tee.bin
42be1ad7 Improve convenience of usage
50719158 Update info related to tee.bin

Combined summary of changes:

Add info regarding network boot.

This patch improves usage of some variables:
  * removes boot_dev variable. Each bootcmd now has it's own *_dtb_load
    with specific boot device
  * added reminders to make easier to remember mapping of bootcmd and
    corresponding boot device
  * naming of variables for network boot (tftp) changed to be unified
    with other devices
  * change name of flash_loaders to flash_z_loaders so it will be not
    lost inside other flash_* names

For some products build system was updated and there can be found two
binaries of tee.bin - with and without header.
Corresponding section was updated with info how to handle these binaries.

Signed-off-by: Ruslan Shymkevych <ruslan_shymkevych@epam.com>