### PR TITLE
domd: add proc-xen.mount to sndbe.service as requires field

### DIFF
--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/sndbe.service
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/sndbe.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Sound backend
-Requires=pulseaudio.service
+Requires=proc-xen.mount pulseaudio.service
+After=proc-xen.mount pulseaudio.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
sndbe requires proc-xen mount same as displbe service.

Signed-off-by: Oleksandr Grytsov <oleksandr_grytsov@epam.com>