### PR TITLE
domd: Avoid using .ipk files with hardcoded names

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -145,7 +145,7 @@ rcar-proprietary-graphic-salvator-xs-h3-4x2g-xt-domd.tar.gz
 AOS VIS prebuilts:
 
 AOS_VIS_PACKAGE_DIR should points to the directory with:
-aos-vis_git-r0_aarch64.ipk, ca-certificates_20170717-r0_all.ipk
+aos-vis package and symbolic link to corresponding *.ipk package.
 
 
 5. Run the build script for current stable release:

--- a/recipes-domd/domd-image-weston/domd-image-weston.bbappend
+++ b/recipes-domd/domd-image-weston/domd-image-weston.bbappend
@@ -174,6 +174,6 @@ do_install_append () {
     find ${LAYERDIR}/doc -iname "u-boot-env*" -exec cp -f {} ${DEPLOY_DIR}/domd-image-weston/images/${MACHINE}-xt \; || true
     find ${LAYERDIR}/doc -iname "mk_sdcard_image.sh" -exec cp -f {} ${DEPLOY_DIR}/domd-image-weston/images/${MACHINE}-xt \; \
     -exec cp -f {} ${DEPLOY_DIR} \; || true
-    find ${DEPLOY_DIR}/${PN}/ipk/aarch64 -iname "aos-vis_git*" -exec cp -f {} ${DEPLOY_DIR}/domd-image-weston/images/${MACHINE}-xt \; || true
-    find ${DEPLOY_DIR}/${PN}/ipk/all -iname "ca-certificates_*" -exec cp -f {} ${DEPLOY_DIR}/domd-image-weston/images/${MACHINE}-xt \; || true
+    find ${DEPLOY_DIR}/${PN}/ipk/aarch64 -iname "aos-vis_git*" -exec cp -f {} ${DEPLOY_DIR}/domd-image-weston/images/${MACHINE}-xt \; && \
+    find ${DEPLOY_DIR}/domd-image-weston/images/${MACHINE}-xt -iname "aos-vis_git*" -exec ln -sfr {} ${DEPLOY_DIR}/domd-image-weston/images/${MACHINE}-xt/aos-vis \; || true
 }

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-graphics/images/core-image-weston.bbappend
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-graphics/images/core-image-weston.bbappend
@@ -56,8 +56,7 @@ IMAGE_POSTPROCESS_COMMAND += "populate_vmlinux; "
 
 install_aos () {
     if [ ! -z "${AOS_VIS_PACKAGE_DIR}" ];then
-        opkg install ${AOS_VIS_PACKAGE_DIR}/ca-certificates_20170717-r0_all.ipk \
-                     ${AOS_VIS_PACKAGE_DIR}/aos-vis_git-r0_aarch64.ipk
+        opkg install ${AOS_VIS_PACKAGE_DIR}/aos-vis
     fi
 }
 


### PR DESCRIPTION
Generate symbolic links instead of using .ipk files with
hard coded names in recipes because file name might be
dynamically changed depending on date.

Signed-off-by: Iurii Artemenko <iurii_artemenko@epam.com>