### PR TITLE
Set default sink for KF

### DIFF
--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-multimedia/pulseaudio/files/system.pa
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-multimedia/pulseaudio/files/system.pa
@@ -62,3 +62,6 @@ load-module module-bluetooth-policy
 .ifexists module-bluetooth-discover.so
 load-module module-bluetooth-discover headset=auto
 .endif
+
+# use pcm3168 on KF
+set-default-sink alsa_output.platform-sound_0.multichannel-output


### PR DESCRIPTION
Set pcm3168a as default playback device on Kingfisher.

Signed-off-by: Ruslan Shymkevych <ruslan_shymkevych@epam.com>