### PR TITLE
domd: kingfisher: Revert changes added by "cairo" receipt ...

### DIFF
--- a/recipes-domd/domd-image-weston/domd-image-weston.bbappend
+++ b/recipes-domd/domd-image-weston/domd-image-weston.bbappend
@@ -45,6 +45,11 @@ configure_versions_kingfisher() {
     # Do not enable surroundview which cannot be used
     base_add_conf_value ${local_conf} DISTRO_FEATURES_remove " surroundview"
     base_update_conf_value ${local_conf} PACKAGECONFIG_remove_pn-libcxx "unwind"
+
+    # Remove the following if we use prebuilt EVA proprietary "graphics" packages
+    if [ ! -z ${XT_RCAR_EVAPROPRIETARY_DIR} ];then
+        base_update_conf_value ${local_conf} PACKAGECONFIG_remove_pn-cairo " egl glesv2"
+    fi
 }
 
 python do_configure_append_h3ulcb-4x2g-kf() {


### PR DESCRIPTION
 ... if we use prebuilt EVA proprietary "graphics" packages

Otherwise, make complains about the undefined reference to:
- wayland_kms_uninit
- gbm_device_get_fd
- gbm_create_device
- wayland_kms_query_buffer
- wayland_kms_init
- _gbm_fd_get_device_name
and as the result fails.

Signed-off-by: Oleksandr Tyshchenko <oleksandr_tyshchenko@epam.com>