### PR TITLE
domd: Conditionally remove AOS-VIS

### DIFF
--- a/recipes-domd/domd-image-weston/domd-image-weston.bbappend
+++ b/recipes-domd/domd-image-weston/domd-image-weston.bbappend
@@ -8,7 +8,7 @@ python __anonymous () {
     product_name = d.getVar('XT_PRODUCT_NAME', True)
     folder_name = product_name.replace("-", "_")
     d.setVar('XT_MANIFEST_FOLDER', folder_name)
-    if product_name == "prod-devel-src":
+    if product_name == "prod-devel-src" and not "domu" in d.getVar('XT_GUESTS_BUILD', True).split():
         d.appendVar("XT_QUIRK_BB_ADD_LAYER", "meta-aos")
 }
 

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-graphics/images/core-image-weston.bbappend
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-graphics/images/core-image-weston.bbappend
@@ -14,7 +14,7 @@ IMAGE_INSTALL_append = " \
 "
 
 python __anonymous () {
-    if (d.getVar("AOS_VIS_PACKAGE_DIR", True) or "") == "":
+    if (d.getVar("AOS_VIS_PACKAGE_DIR", True) or "") == "" and not "domu" in (d.getVar("XT_GUESTS_INSTALL", True).split()):
         d.appendVar("IMAGE_INSTALL", "aos-vis")
 }
 
@@ -47,6 +47,9 @@ populate_vmlinux () {
 IMAGE_POSTPROCESS_COMMAND += "populate_vmlinux; "
 
 install_aos () {
+    if echo "${XT_GUESTS_INSTALL}" | grep -qi "domu";then
+        exit 0
+    fi
     if [ ! -z "${AOS_VIS_PACKAGE_DIR}" ];then
         opkg install ${AOS_VIS_PACKAGE_DIR}/aos-vis
     fi


### PR DESCRIPTION
When build with DomU we do not use AOS-VIS so conditionally
remove it from rootfs image and meta-layers. Also do not
install AOS-VIS binary package for DomU based product.

Signed-off-by: Iurii Artemenko <iurii_artemenko@epam.com>