### PR TITLE
Use dedicated PulseAudio config for SK_KF and remove udev-detect

### DIFF
--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-multimedia/pulseaudio/files/kingfisher/system.pa
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-multimedia/pulseaudio/files/kingfisher/system.pa
@@ -23,7 +23,14 @@
 ## MOST drivers does not like how pulse probing it and crashes system
 
 ### Force use of ALSA
-load-module module-udev-detect
+# load-module module-udev-detect
+# This script is dedicated for Starterkit with Kingfisher, so we know
+# audio cards used, and we can load modules directly without udev-detect.
+# card 0 is pcm3168a
+load-module module-alsa-card device_id="0"
+# card 1 is ak4613
+load-module module-alsa-card device_id="1"
+# for now we do not load alsa-card modules for radio and BT
 
 ### Load several protocols
 .ifexists module-esound-protocol-unix.so
@@ -63,3 +70,5 @@ load-module module-bluetooth-policy
 load-module module-bluetooth-discover headset=auto
 .endif
 
+# use pcm3168 on KF
+set-default-sink alsa_output.0.multichannel-output


### PR DESCRIPTION
We used to use udev-detect module to find availabe cards, but this
results in two issues:
1) not predictible order of soundcards
2) sometimes pcm3168a is detected and loaded to slow, and system.pa
script is not able to set it as default.

Patch solves these issues by removing udev-detect and directly loading
alsa-card modules for each sound card. At this point we need to separate
system.pa for SK+KF and other cards, as far as we have only ak4613 on
all boards (salvator-x, -xs, starterkit) exept starterkit with kingfisher
where we have pcm3168a, ak4613, radio and bt. Last two are not used
for now so alsa-card module is not loaded for them.

Signed-off-by: Ruslan Shymkevych <ruslan_shymkevych@epam.com>