### PR TITLE
domu: enhance editing experience in domain shell

### DIFF
--- a/recipes-domu/domu-image-weston/files/meta-xt-prod-extra/recipes-core/base-files/base-files_%.bbappend
+++ b/recipes-domu/domu-image-weston/files/meta-xt-prod-extra/recipes-core/base-files/base-files_%.bbappend
@@ -5,4 +5,6 @@ hostname .= "-domu"
 
 do_install_append () {
 	sed -i '/PATH="/a PATH="$PATH:${base_prefix}${XT_DIR_ABS_ROOTFS_SCRIPTS}"' ${D}${sysconfdir}/profile
+	echo "shopt -s checkwinsize" >> ${D}${sysconfdir}/profile
+	echo "resize 1> /dev/null" >> ${D}${sysconfdir}/profile
 }


### PR DESCRIPTION
"shopt -s checkwinsize" - will change the behaviour of command
placement in shell input. I.e. will not wrap input, but
continue it from the next line if it too big.

"resize" - set environment and terminal settings to current
xterm window size

Suggested-by: Viktor Mitin <viktor_mitin@epam.com>
Signed-off-by: Andrii Chepurnyi <andrii_chepurnyi@epam.com>
Signed-off-by: Ruslan Shymkevych <ruslan_shymkevych@epam.com>