### PR TITLE
domd: Add ca-certificates into the rootfs

### DIFF
--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-graphics/images/core-image-weston.bbappend
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-graphics/images/core-image-weston.bbappend
@@ -16,6 +16,8 @@ IMAGE_INSTALL_append = " \
 python __anonymous () {
     if (d.getVar("AOS_VIS_PACKAGE_DIR", True) or "") == "" and not "domu" in (d.getVar("XT_GUESTS_INSTALL", True).split()):
         d.appendVar("IMAGE_INSTALL", "aos-vis")
+    if (d.getVar("AOS_VIS_PACKAGE_DIR", True) or "") != "" and not "domu" in (d.getVar("XT_GUESTS_INSTALL", True).split()):
+        d.appendVar("IMAGE_INSTALL", "ca-certificates")
 }
 
 # Configuration for ARM Trusted Firmware


### PR DESCRIPTION
Conditionally install ca-certificates in case we
install aos-vis as a prebuilt binary.

Signed-off-by: Iurii Artemenko <iurii_artemenko@epam.com>