### PR TITLE
dom0: Reduce XT page/CMA allocator size in guest domains

### DIFF
--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/doma-salvator-generic.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/doma-salvator-generic.cfg
@@ -32,7 +32,7 @@ disk = [
 ]
 
 # Kernel command line options
-extra = "ip=dhcp root=/dev/xvda1 androidboot.hardware=xenvm skip_initramfs init=/init ro rootwait console=hvc0 cma=256M@1-2G printk.devkmsg=on androidboot.selinux=permissive pvrsrvkm.DriverMode=1 androidboot.android_dt_dir=/proc/device-tree/firmware#1/android/"
+extra = "ip=dhcp root=/dev/xvda1 androidboot.hardware=xenvm skip_initramfs init=/init ro rootwait console=hvc0 cma=256M@1-2G printk.devkmsg=on androidboot.selinux=permissive pvrsrvkm.DriverMode=1 androidboot.android_dt_dir=/proc/device-tree/firmware#1/android/ xt_page_pool=2097152 xt_cma=4194304"
 
 # Initial memory allocation (MB)
 memory = 2192

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/doma-salvator-x-h3-4x2g.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/doma-salvator-x-h3-4x2g.cfg
@@ -39,7 +39,7 @@ disk = [
 ]
 
 # Kernel command line options
-extra = "ip=dhcp root=/dev/xvda1 androidboot.hardware=xenvm skip_initramfs init=/init ro rootwait console=hvc0 cma=256M@1-2G printk.devkmsg=on androidboot.selinux=permissive pvrsrvkm.DriverMode=1 androidboot.android_dt_dir=/proc/device-tree/firmware#1/android/"
+extra = "ip=dhcp root=/dev/xvda1 androidboot.hardware=xenvm skip_initramfs init=/init ro rootwait console=hvc0 cma=256M@1-2G printk.devkmsg=on androidboot.selinux=permissive pvrsrvkm.DriverMode=1 androidboot.android_dt_dir=/proc/device-tree/firmware#1/android/ xt_page_pool=2097152 xt_cma=4194304"
 
 # Initial memory allocation (MB)
 memory = 6064

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domd-h3ulcb-4x2g-kf.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domd-h3ulcb-4x2g-kf.cfg
@@ -14,9 +14,9 @@ device_tree = "/xt/domd/domd.dtb"
 
 # Kernel command line options
 # Uncomment this when using nfs as a boot device
-#extra = "root=/dev/nfs nfsroot=192.168.1.100:/srv/domd,vers=3 ip=dhcp rw rootwait console=hvc0 pvrsrvkm.DriverMode=0"
+#extra = "root=/dev/nfs nfsroot=192.168.1.100:/srv/domd,vers=3 ip=dhcp rw rootwait console=hvc0 pvrsrvkm.DriverMode=0 xt_page_pool=33554432 xt_cma=67108864"
 # Uncomment this when using block device as a boot device
-extra = "root=/dev/STORAGE_PART2 rw rootwait console=hvc0 pvrsrvkm.DriverMode=0"
+extra = "root=/dev/STORAGE_PART2 rw rootwait console=hvc0 pvrsrvkm.DriverMode=0 xt_page_pool=33554432 xt_cma=67108864"
 
 # Initial memory allocation (MB)
 memory = 1216

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domd-h3ulcb-4x2g.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domd-h3ulcb-4x2g.cfg
@@ -14,9 +14,9 @@ device_tree = "/xt/domd/domd.dtb"
 
 # Kernel command line options
 # Uncomment this when using nfs as a boot device
-#extra = "root=/dev/nfs nfsroot=192.168.1.100:/srv/domd,vers=3 ip=dhcp rw rootwait console=hvc0 pvrsrvkm.DriverMode=0"
+#extra = "root=/dev/nfs nfsroot=192.168.1.100:/srv/domd,vers=3 ip=dhcp rw rootwait console=hvc0 pvrsrvkm.DriverMode=0 xt_page_pool=33554432 xt_cma=67108864"
 # Uncomment this when using block device as a boot device
-extra = "root=/dev/STORAGE_PART2 rw rootwait console=hvc0 pvrsrvkm.DriverMode=0"
+extra = "root=/dev/STORAGE_PART2 rw rootwait console=hvc0 pvrsrvkm.DriverMode=0 xt_page_pool=33554432 xt_cma=67108864"
 
 # Initial memory allocation (MB)
 memory = 1216

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domd-h3ulcb.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domd-h3ulcb.cfg
@@ -14,9 +14,9 @@ device_tree = "/xt/domd/domd.dtb"
 
 # Kernel command line options
 # Uncomment this when using nfs as a boot device
-#extra = "root=/dev/nfs nfsroot=192.168.1.100:/srv/domd,vers=3 ip=dhcp rw rootwait console=hvc0 pvrsrvkm.DriverMode=0"
+#extra = "root=/dev/nfs nfsroot=192.168.1.100:/srv/domd,vers=3 ip=dhcp rw rootwait console=hvc0 pvrsrvkm.DriverMode=0 xt_page_pool=33554432 xt_cma=67108864"
 # Uncomment this when using block device as a boot device
-extra = "root=/dev/STORAGE_PART2 rw rootwait console=hvc0 pvrsrvkm.DriverMode=0"
+extra = "root=/dev/STORAGE_PART2 rw rootwait console=hvc0 pvrsrvkm.DriverMode=0 xt_page_pool=33554432 xt_cma=67108864"
 
 # Initial memory allocation (MB)
 memory = 1216

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domd-salvator-x-h3-4x2g.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domd-salvator-x-h3-4x2g.cfg
@@ -14,9 +14,9 @@ device_tree = "/xt/domd/domd.dtb"
 
 # Kernel command line options
 # Uncomment this when using nfs as a boot device
-#extra = "root=/dev/nfs nfsroot=192.168.1.100:/srv/domd,vers=3 ip=dhcp rw rootwait console=hvc0 pvrsrvkm.DriverMode=0"
+#extra = "root=/dev/nfs nfsroot=192.168.1.100:/srv/domd,vers=3 ip=dhcp rw rootwait console=hvc0 pvrsrvkm.DriverMode=0 xt_page_pool=33554432 xt_cma=67108864"
 # Uncomment this when using block device as a boot device
-extra = "root=/dev/STORAGE_PART2 rw rootwait console=hvc0 pvrsrvkm.DriverMode=0"
+extra = "root=/dev/STORAGE_PART2 rw rootwait console=hvc0 pvrsrvkm.DriverMode=0 xt_page_pool=33554432 xt_cma=67108864"
 
 # Initial memory allocation (MB)
 memory = 1216

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domd-salvator-x-h3.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domd-salvator-x-h3.cfg
@@ -14,9 +14,9 @@ device_tree = "/xt/domd/domd.dtb"
 
 # Kernel command line options
 # Uncomment this when using nfs as a boot device
-#extra = "root=/dev/nfs nfsroot=192.168.1.100:/srv/domd,vers=3 ip=dhcp rw rootwait console=hvc0 pvrsrvkm.DriverMode=0"
+#extra = "root=/dev/nfs nfsroot=192.168.1.100:/srv/domd,vers=3 ip=dhcp rw rootwait console=hvc0 pvrsrvkm.DriverMode=0 xt_page_pool=33554432 xt_cma=67108864"
 # Uncomment this when using block device as a boot device
-extra = "root=/dev/STORAGE_PART2 rw rootwait console=hvc0 pvrsrvkm.DriverMode=0"
+extra = "root=/dev/STORAGE_PART2 rw rootwait console=hvc0 pvrsrvkm.DriverMode=0 xt_page_pool=33554432 xt_cma=67108864"
 
 # Initial memory allocation (MB)
 memory = 1216

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domd-salvator-x-m3.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domd-salvator-x-m3.cfg
@@ -14,9 +14,9 @@ device_tree = "/xt/domd/domd.dtb"
 
 # Kernel command line options
 # Uncomment this when using nfs as a boot device
-#extra = "root=/dev/nfs nfsroot=192.168.1.100:/srv/domd,vers=3 ip=dhcp rw rootwait console=hvc0 pvrsrvkm.DriverMode=0"
+#extra = "root=/dev/nfs nfsroot=192.168.1.100:/srv/domd,vers=3 ip=dhcp rw rootwait console=hvc0 pvrsrvkm.DriverMode=0 xt_page_pool=33554432 xt_cma=67108864"
 # Uncomment this when using block device as a boot device
-extra = "root=/dev/STORAGE_PART2 rw rootwait console=hvc0 pvrsrvkm.DriverMode=0"
+extra = "root=/dev/STORAGE_PART2 rw rootwait console=hvc0 pvrsrvkm.DriverMode=0 xt_page_pool=33554432 xt_cma=67108864"
 
 # Initial memory allocation (MB)
 memory = 1216

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domd-salvator-xs-h3-4x2g.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domd-salvator-xs-h3-4x2g.cfg
@@ -14,9 +14,9 @@ device_tree = "/xt/domd/domd.dtb"
 
 # Kernel command line options
 # Uncomment this when using nfs as a boot device
-#extra = "root=/dev/nfs nfsroot=192.168.1.100:/srv/domd,vers=3 ip=dhcp rw rootwait console=hvc0 pvrsrvkm.DriverMode=0"
+#extra = "root=/dev/nfs nfsroot=192.168.1.100:/srv/domd,vers=3 ip=dhcp rw rootwait console=hvc0 pvrsrvkm.DriverMode=0 xt_page_pool=33554432 xt_cma=67108864"
 # Uncomment this when using block device as a boot device
-extra = "root=/dev/STORAGE_PART2 rw rootwait console=hvc0 pvrsrvkm.DriverMode=0"
+extra = "root=/dev/STORAGE_PART2 rw rootwait console=hvc0 pvrsrvkm.DriverMode=0 xt_page_pool=33554432 xt_cma=67108864"
 
 # Initial memory allocation (MB)
 memory = 1216

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domd-salvator-xs-h3.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domd-salvator-xs-h3.cfg
@@ -14,9 +14,9 @@ device_tree = "/xt/domd/domd.dtb"
 
 # Kernel command line options
 # Uncomment this when using nfs as a boot device
-#extra = "root=/dev/nfs nfsroot=192.168.1.100:/srv/domd,vers=3 ip=dhcp rw rootwait console=hvc0 pvrsrvkm.DriverMode=0"
+#extra = "root=/dev/nfs nfsroot=192.168.1.100:/srv/domd,vers=3 ip=dhcp rw rootwait console=hvc0 pvrsrvkm.DriverMode=0 xt_page_pool=33554432 xt_cma=67108864"
 # Uncomment this when using block device as a boot device
-extra = "root=/dev/STORAGE_PART2 rw rootwait console=hvc0 pvrsrvkm.DriverMode=0"
+extra = "root=/dev/STORAGE_PART2 rw rootwait console=hvc0 pvrsrvkm.DriverMode=0 xt_page_pool=33554432 xt_cma=67108864"
 
 # Initial memory allocation (MB)
 memory = 1216

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domu-h3ulcb.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domu-h3ulcb.cfg
@@ -14,9 +14,9 @@ device_tree = "/xt/domd/domu.dtb"
 
 # Kernel command line options
 # Uncomment this when using nfs as a boot device
-#extra = "root=/dev/nfs nfsroot=192.168.1.100:/srv/domu,vers=3 ip=dhcp rw rootwait console=hvc0 cma=256M@1-2G pvrsrvkm.DriverMode=1"
+#extra = "root=/dev/nfs nfsroot=192.168.1.100:/srv/domu,vers=3 ip=dhcp rw rootwait console=hvc0 cma=256M@1-2G pvrsrvkm.DriverMode=1 xt_page_pool=2097152 xt_cma=4194304"
 # Uncomment this when using block device as a boot device
-extra = "root=/dev/xvda1 rw rootwait console=hvc0 cma=256M@1-2G pvrsrvkm.DriverMode=1"
+extra = "root=/dev/xvda1 rw rootwait console=hvc0 cma=256M@1-2G pvrsrvkm.DriverMode=1 xt_page_pool=2097152 xt_cma=4194304"
 
 # Initial memory allocation (MB)
 memory = 1536

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domu-salvator-x-h3-4x2g.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domu-salvator-x-h3-4x2g.cfg
@@ -21,9 +21,9 @@ dtdev = [
 
 # Kernel command line options
 # Uncomment this when using nfs as a boot device
-#extra = "root=/dev/nfs nfsroot=192.168.1.100:/srv/domu,vers=3 ip=dhcp rw rootwait console=hvc0 cma=256M@1-2G pvrsrvkm.DriverMode=1"
+#extra = "root=/dev/nfs nfsroot=192.168.1.100:/srv/domu,vers=3 ip=dhcp rw rootwait console=hvc0 cma=256M@1-2G pvrsrvkm.DriverMode=1 xt_page_pool=2097152 xt_cma=4194304"
 # Uncomment this when using block device as a boot device
-extra = "root=/dev/xvda1 rw rootwait console=hvc0 cma=256M@1-2G pvrsrvkm.DriverMode=1"
+extra = "root=/dev/xvda1 rw rootwait console=hvc0 cma=256M@1-2G pvrsrvkm.DriverMode=1 xt_page_pool=2097152 xt_cma=4194304"
 
 # Initial memory allocation (MB)
 memory = 1536

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domu-salvator-x-h3.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domu-salvator-x-h3.cfg
@@ -14,9 +14,9 @@ device_tree = "/xt/domd/domu.dtb"
 
 # Kernel command line options
 # Uncomment this when using nfs as a boot device
-#extra = "root=/dev/nfs nfsroot=192.168.1.100:/srv/domu,vers=3 ip=dhcp rw rootwait console=hvc0 cma=256M@1-2G pvrsrvkm.DriverMode=1"
+#extra = "root=/dev/nfs nfsroot=192.168.1.100:/srv/domu,vers=3 ip=dhcp rw rootwait console=hvc0 cma=256M@1-2G pvrsrvkm.DriverMode=1 xt_page_pool=2097152 xt_cma=4194304"
 # Uncomment this when using block device as a boot device
-extra = "root=/dev/xvda1 rw rootwait console=hvc0 cma=256M@1-2G pvrsrvkm.DriverMode=1"
+extra = "root=/dev/xvda1 rw rootwait console=hvc0 cma=256M@1-2G pvrsrvkm.DriverMode=1 xt_page_pool=2097152 xt_cma=4194304"
 
 # Initial memory allocation (MB)
 memory = 1536

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domu-salvator-x-m3.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domu-salvator-x-m3.cfg
@@ -14,9 +14,9 @@ device_tree = "/xt/domd/domu.dtb"
 
 # Kernel command line options
 # Uncomment this when using nfs as a boot device
-#extra = "root=/dev/nfs nfsroot=192.168.1.100:/srv/domu,vers=3 ip=dhcp rw rootwait console=hvc0 cma=256M@1-2G pvrsrvkm.DriverMode=1"
+#extra = "root=/dev/nfs nfsroot=192.168.1.100:/srv/domu,vers=3 ip=dhcp rw rootwait console=hvc0 cma=256M@1-2G pvrsrvkm.DriverMode=1 xt_page_pool=2097152 xt_cma=4194304"
 # Uncomment this when using block device as a boot device
-extra = "root=/dev/xvda1 rw rootwait console=hvc0 cma=256M@1-2G pvrsrvkm.DriverMode=1"
+extra = "root=/dev/xvda1 rw rootwait console=hvc0 cma=256M@1-2G pvrsrvkm.DriverMode=1 xt_page_pool=2097152 xt_cma=4194304"
 
 # Initial memory allocation (MB)
 memory = 1536


### PR DESCRIPTION
Set the following values for all machines except m3ulcb/salvator-xs-m3n
(these two machines already have actual values):
1. For DomD:
   XT page allocator size - 32MB
   XT CMA allocator size - 64MB

2. For DomU/DomA:
   XT page allocator size - 2MB
   XT CMA allocator size - 4MB

Signed-off-by: Oleksandr Tyshchenko <oleksandr_tyshchenko@epam.com>