### PR TITLE
dom0: Reconsider XT CMA allocator size in DomD

### DIFF
--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/doma-salvator-generic.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/doma-salvator-generic.cfg
@@ -35,7 +35,7 @@ disk = [
 extra = "ip=dhcp root=/dev/xvda1 androidboot.hardware=xenvm skip_initramfs init=/init ro rootwait console=hvc0 cma=256M@1-2G printk.devkmsg=on androidboot.selinux=permissive pvrsrvkm.DriverMode=1 androidboot.android_dt_dir=/proc/device-tree/firmware#1/android/ xt_page_pool=2097152 xt_cma=4194304"
 
 # Initial memory allocation (MB)
-memory = 2192
+memory = 2160
 
 # Number of VCPUS
 vcpus = 4

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/doma-salvator-x-h3-4x2g.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/doma-salvator-x-h3-4x2g.cfg
@@ -42,7 +42,7 @@ disk = [
 extra = "ip=dhcp root=/dev/xvda1 androidboot.hardware=xenvm skip_initramfs init=/init ro rootwait console=hvc0 cma=256M@1-2G printk.devkmsg=on androidboot.selinux=permissive pvrsrvkm.DriverMode=1 androidboot.android_dt_dir=/proc/device-tree/firmware#1/android/ xt_page_pool=2097152 xt_cma=4194304"
 
 # Initial memory allocation (MB)
-memory = 6064
+memory = 6032
 
 # Number of VCPUS
 vcpus = 4

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domd-h3ulcb-4x2g-kf.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domd-h3ulcb-4x2g-kf.cfg
@@ -14,12 +14,12 @@ device_tree = "/xt/domd/domd.dtb"
 
 # Kernel command line options
 # Uncomment this when using nfs as a boot device
-#extra = "root=/dev/nfs nfsroot=192.168.1.100:/srv/domd,vers=3 ip=dhcp rw rootwait console=hvc0 pvrsrvkm.DriverMode=0 xt_page_pool=33554432 xt_cma=67108864"
+#extra = "root=/dev/nfs nfsroot=192.168.1.100:/srv/domd,vers=3 ip=dhcp rw rootwait console=hvc0 pvrsrvkm.DriverMode=0 xt_page_pool=33554432 xt_cma=100663296"
 # Uncomment this when using block device as a boot device
-extra = "root=/dev/STORAGE_PART2 rw rootwait console=hvc0 pvrsrvkm.DriverMode=0 xt_page_pool=33554432 xt_cma=67108864"
+extra = "root=/dev/STORAGE_PART2 rw rootwait console=hvc0 pvrsrvkm.DriverMode=0 xt_page_pool=33554432 xt_cma=100663296"
 
 # Initial memory allocation (MB)
-memory = 1216
+memory = 1248
 
 # Number of VCPUS
 vcpus = 4

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domd-h3ulcb-4x2g.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domd-h3ulcb-4x2g.cfg
@@ -14,12 +14,12 @@ device_tree = "/xt/domd/domd.dtb"
 
 # Kernel command line options
 # Uncomment this when using nfs as a boot device
-#extra = "root=/dev/nfs nfsroot=192.168.1.100:/srv/domd,vers=3 ip=dhcp rw rootwait console=hvc0 pvrsrvkm.DriverMode=0 xt_page_pool=33554432 xt_cma=67108864"
+#extra = "root=/dev/nfs nfsroot=192.168.1.100:/srv/domd,vers=3 ip=dhcp rw rootwait console=hvc0 pvrsrvkm.DriverMode=0 xt_page_pool=33554432 xt_cma=100663296"
 # Uncomment this when using block device as a boot device
-extra = "root=/dev/STORAGE_PART2 rw rootwait console=hvc0 pvrsrvkm.DriverMode=0 xt_page_pool=33554432 xt_cma=67108864"
+extra = "root=/dev/STORAGE_PART2 rw rootwait console=hvc0 pvrsrvkm.DriverMode=0 xt_page_pool=33554432 xt_cma=100663296"
 
 # Initial memory allocation (MB)
-memory = 1216
+memory = 1248
 
 # Number of VCPUS
 vcpus = 4

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domd-h3ulcb.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domd-h3ulcb.cfg
@@ -14,12 +14,12 @@ device_tree = "/xt/domd/domd.dtb"
 
 # Kernel command line options
 # Uncomment this when using nfs as a boot device
-#extra = "root=/dev/nfs nfsroot=192.168.1.100:/srv/domd,vers=3 ip=dhcp rw rootwait console=hvc0 pvrsrvkm.DriverMode=0 xt_page_pool=33554432 xt_cma=67108864"
+#extra = "root=/dev/nfs nfsroot=192.168.1.100:/srv/domd,vers=3 ip=dhcp rw rootwait console=hvc0 pvrsrvkm.DriverMode=0 xt_page_pool=33554432 xt_cma=100663296"
 # Uncomment this when using block device as a boot device
-extra = "root=/dev/STORAGE_PART2 rw rootwait console=hvc0 pvrsrvkm.DriverMode=0 xt_page_pool=33554432 xt_cma=67108864"
+extra = "root=/dev/STORAGE_PART2 rw rootwait console=hvc0 pvrsrvkm.DriverMode=0 xt_page_pool=33554432 xt_cma=100663296"
 
 # Initial memory allocation (MB)
-memory = 1216
+memory = 1248
 
 # Number of VCPUS
 vcpus = 4

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domd-salvator-x-h3-4x2g.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domd-salvator-x-h3-4x2g.cfg
@@ -14,12 +14,12 @@ device_tree = "/xt/domd/domd.dtb"
 
 # Kernel command line options
 # Uncomment this when using nfs as a boot device
-#extra = "root=/dev/nfs nfsroot=192.168.1.100:/srv/domd,vers=3 ip=dhcp rw rootwait console=hvc0 pvrsrvkm.DriverMode=0 xt_page_pool=33554432 xt_cma=67108864"
+#extra = "root=/dev/nfs nfsroot=192.168.1.100:/srv/domd,vers=3 ip=dhcp rw rootwait console=hvc0 pvrsrvkm.DriverMode=0 xt_page_pool=33554432 xt_cma=100663296"
 # Uncomment this when using block device as a boot device
-extra = "root=/dev/STORAGE_PART2 rw rootwait console=hvc0 pvrsrvkm.DriverMode=0 xt_page_pool=33554432 xt_cma=67108864"
+extra = "root=/dev/STORAGE_PART2 rw rootwait console=hvc0 pvrsrvkm.DriverMode=0 xt_page_pool=33554432 xt_cma=100663296"
 
 # Initial memory allocation (MB)
-memory = 1216
+memory = 1248
 
 # Number of VCPUS
 vcpus = 4

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domd-salvator-x-h3.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domd-salvator-x-h3.cfg
@@ -14,12 +14,12 @@ device_tree = "/xt/domd/domd.dtb"
 
 # Kernel command line options
 # Uncomment this when using nfs as a boot device
-#extra = "root=/dev/nfs nfsroot=192.168.1.100:/srv/domd,vers=3 ip=dhcp rw rootwait console=hvc0 pvrsrvkm.DriverMode=0 xt_page_pool=33554432 xt_cma=67108864"
+#extra = "root=/dev/nfs nfsroot=192.168.1.100:/srv/domd,vers=3 ip=dhcp rw rootwait console=hvc0 pvrsrvkm.DriverMode=0 xt_page_pool=33554432 xt_cma=100663296"
 # Uncomment this when using block device as a boot device
-extra = "root=/dev/STORAGE_PART2 rw rootwait console=hvc0 pvrsrvkm.DriverMode=0 xt_page_pool=33554432 xt_cma=67108864"
+extra = "root=/dev/STORAGE_PART2 rw rootwait console=hvc0 pvrsrvkm.DriverMode=0 xt_page_pool=33554432 xt_cma=100663296"
 
 # Initial memory allocation (MB)
-memory = 1216
+memory = 1248
 
 # Number of VCPUS
 vcpus = 4

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domd-salvator-x-m3.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domd-salvator-x-m3.cfg
@@ -14,12 +14,12 @@ device_tree = "/xt/domd/domd.dtb"
 
 # Kernel command line options
 # Uncomment this when using nfs as a boot device
-#extra = "root=/dev/nfs nfsroot=192.168.1.100:/srv/domd,vers=3 ip=dhcp rw rootwait console=hvc0 pvrsrvkm.DriverMode=0 xt_page_pool=33554432 xt_cma=67108864"
+#extra = "root=/dev/nfs nfsroot=192.168.1.100:/srv/domd,vers=3 ip=dhcp rw rootwait console=hvc0 pvrsrvkm.DriverMode=0 xt_page_pool=33554432 xt_cma=100663296"
 # Uncomment this when using block device as a boot device
-extra = "root=/dev/STORAGE_PART2 rw rootwait console=hvc0 pvrsrvkm.DriverMode=0 xt_page_pool=33554432 xt_cma=67108864"
+extra = "root=/dev/STORAGE_PART2 rw rootwait console=hvc0 pvrsrvkm.DriverMode=0 xt_page_pool=33554432 xt_cma=100663296"
 
 # Initial memory allocation (MB)
-memory = 1216
+memory = 1248
 
 # Number of VCPUS
 vcpus = 4

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domd-salvator-xs-h3-4x2g.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domd-salvator-xs-h3-4x2g.cfg
@@ -14,12 +14,12 @@ device_tree = "/xt/domd/domd.dtb"
 
 # Kernel command line options
 # Uncomment this when using nfs as a boot device
-#extra = "root=/dev/nfs nfsroot=192.168.1.100:/srv/domd,vers=3 ip=dhcp rw rootwait console=hvc0 pvrsrvkm.DriverMode=0 xt_page_pool=33554432 xt_cma=67108864"
+#extra = "root=/dev/nfs nfsroot=192.168.1.100:/srv/domd,vers=3 ip=dhcp rw rootwait console=hvc0 pvrsrvkm.DriverMode=0 xt_page_pool=33554432 xt_cma=100663296"
 # Uncomment this when using block device as a boot device
-extra = "root=/dev/STORAGE_PART2 rw rootwait console=hvc0 pvrsrvkm.DriverMode=0 xt_page_pool=33554432 xt_cma=67108864"
+extra = "root=/dev/STORAGE_PART2 rw rootwait console=hvc0 pvrsrvkm.DriverMode=0 xt_page_pool=33554432 xt_cma=100663296"
 
 # Initial memory allocation (MB)
-memory = 1216
+memory = 1248
 
 # Number of VCPUS
 vcpus = 4

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domd-salvator-xs-h3.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domd-salvator-xs-h3.cfg
@@ -14,12 +14,12 @@ device_tree = "/xt/domd/domd.dtb"
 
 # Kernel command line options
 # Uncomment this when using nfs as a boot device
-#extra = "root=/dev/nfs nfsroot=192.168.1.100:/srv/domd,vers=3 ip=dhcp rw rootwait console=hvc0 pvrsrvkm.DriverMode=0 xt_page_pool=33554432 xt_cma=67108864"
+#extra = "root=/dev/nfs nfsroot=192.168.1.100:/srv/domd,vers=3 ip=dhcp rw rootwait console=hvc0 pvrsrvkm.DriverMode=0 xt_page_pool=33554432 xt_cma=100663296"
 # Uncomment this when using block device as a boot device
-extra = "root=/dev/STORAGE_PART2 rw rootwait console=hvc0 pvrsrvkm.DriverMode=0 xt_page_pool=33554432 xt_cma=67108864"
+extra = "root=/dev/STORAGE_PART2 rw rootwait console=hvc0 pvrsrvkm.DriverMode=0 xt_page_pool=33554432 xt_cma=100663296"
 
 # Initial memory allocation (MB)
-memory = 1216
+memory = 1248
 
 # Number of VCPUS
 vcpus = 4


### PR DESCRIPTION
Current XT CMA allocator size (64MB) was believed to be enough
for running single DomU/DomA (where display systems use
"double-buffering" mode) with PV PVRKM and PV Display running.

But as it turned out, that value is insufficient for running Weston
applications in fullscreen mode on DomU. In this case more display memory
needs to be mapped from DomU to DomD at run-time.

This patch increases both DomD memory and xt_cma size by 32MB and
decreases DomA memory by 32MB respectively (we do not need to decrease
DomU memory as we provide only 1536MB to it).

Please note, XT CMA allocator size should be reconsidered again
if, for example, there is a need to run two DomU/DomA with display
and graphic enabled or enable "triple/quad-buffering" mode for
display systems on these domains.

Reported-by: Yoshihito Ogawa <yoshihito.ogawa.kc@renesas.com>
Signed-off-by: Oleksandr Tyshchenko <oleksandr_tyshchenko@epam.com>