### PR TITLE
domd: Optimize append of multimedia features to build

### DIFF
--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/doc/local.conf.rcar-domd-image-weston
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/doc/local.conf.rcar-domd-image-weston
@@ -278,13 +278,13 @@ PREFERRED_PROVIDER_virtual/libgbm = "libgbm"
 PREFERRED_PROVIDER_libgbm-dev = "libgbm"
 BBMASK .= "|mesa-gl"
 
-# Enable Multimedia features
-MACHINE_FEATURES_append = " multimedia"
+# Enable Multimedia features if XT_RCAR_PROPRIETARY_MULTIMEDIA_DIR is defined
+MACHINE_FEATURES_append = "${@bb.utils.contains('XT_RCAR_PROPRIETARY_MULTIMEDIA_DIR', '', '', ' multimedia', d)}"
 
 # for gstreamer omx plugins
 LICENSE_FLAGS_WHITELIST = "commercial"
 # for mmp test program
-DISTRO_FEATURES_append = " mm-test"
+DISTRO_FEATURES_append = "${@bb.utils.contains('XT_RCAR_PROPRIETARY_MULTIMEDIA_DIR', '', '', ' mm-test', d)}"
 
 # for weston v4l2 renderer
 #DISTRO_FEATURES_append = " v4l2-renderer"
@@ -293,10 +293,10 @@ DISTRO_FEATURES_append = " mm-test"
 #DISTRO_FEATURES_append = " h263dec_lib"
 
 # OMX H264 decoder library for Linux (RTM0AC0000XV264D30SL41C)
-DISTRO_FEATURES_append = " h264dec_lib"
+DISTRO_FEATURES_append = "${@bb.utils.contains('XT_RCAR_PROPRIETARY_MULTIMEDIA_DIR', '', '', ' h264dec_lib', d)}"
 
 # OMX H264 encoder library for Linux (RTM0AC0000XV264E30SL41C)
-DISTRO_FEATURES_append = " h264enc_lib"
+DISTRO_FEATURES_append = "${@bb.utils.contains('XT_RCAR_PROPRIETARY_MULTIMEDIA_DIR', '', '', ' h264enc_lib', d)}"
 
 # OMX H265 decoder library for Linux (RTM0AC0000XV265D30SL41C)
 #DISTRO_FEATURES_append = " h265dec_lib"
@@ -324,8 +324,8 @@ DISTRO_FEATURES_append = " h264enc_lib"
 
 # OMX AAC-LC decoder library for Linux (RTM0AC0000XAAACD30SL41C),
 # AAC-LC 2ch decoder middleware library for Linux (RTM0AC0000ADAACMZ1SL41C)
-DISTRO_FEATURES_append = " aaclcdec_lib"
-DISTRO_FEATURES_append = " aaclcdec_mdw"
+DISTRO_FEATURES_append = "${@bb.utils.contains('XT_RCAR_PROPRIETARY_MULTIMEDIA_DIR', '', '', ' aaclcdec_lib', d)}"
+DISTRO_FEATURES_append = "${@bb.utils.contains('XT_RCAR_PROPRIETARY_MULTIMEDIA_DIR', '', '', ' aaclcdec_mdw', d)}"
 
 # OMX aacPlus V2 decoder library for Linux (RTM0AC0000XAAAPD30SL41C),
 # aacPlus V2 decoder middleware library for Linux (RTM0AC0000ADAAPMZ1SL41C)
@@ -391,7 +391,7 @@ DISTRO_FEATURES_append = " aaclcdec_mdw"
 #DISTRO_FEATURES_append = " iccom"
 
 # Evaluation packages
-DISTRO_FEATURES_append = " use_eva_pkg"
+DISTRO_FEATURES_append = "${@bb.utils.contains('XT_RCAR_PROPRIETARY_MULTIMEDIA_DIR', '', '', ' use_eva_pkg', d)}"
 
 # Configuration for ivi-shell and ivi-extension
 DISTRO_FEATURES_append = " ivi-shell"
@@ -407,15 +407,6 @@ DISTRO_FEATURES_append = " virtualization"
 MACHINEOVERRIDES .= ":rcar"
 
 DISTRO_FEATURES_remove = " x11 gtk gobject-introspection-data nfc irda zeroconf 3g"
-
-# Remove multimedia options if XT_RCAR_PROPRIETARY_MULTIMEDIA_DIR is not defined
-MACHINE_FEATURES_remove = " ${@bb.utils.contains('XT_RCAR_PROPRIETARY_MULTIMEDIA_DIR','','','multimedia', d)}"
-DISTRO_FEATURES_remove = " ${@bb.utils.contains('XT_RCAR_PROPRIETARY_MULTIMEDIA_DIR','','','mm-test', d)}"
-DISTRO_FEATURES_remove = " ${@bb.utils.contains('XT_RCAR_PROPRIETARY_MULTIMEDIA_DIR','','','h264dec_lib', d)}"
-DISTRO_FEATURES_remove = " ${@bb.utils.contains('XT_RCAR_PROPRIETARY_MULTIMEDIA_DIR','','','h264enc_lib', d)}"
-DISTRO_FEATURES_remove = " ${@bb.utils.contains('XT_RCAR_PROPRIETARY_MULTIMEDIA_DIR','','','aaclcdec_lib', d)}"
-DISTRO_FEATURES_remove = " ${@bb.utils.contains('XT_RCAR_PROPRIETARY_MULTIMEDIA_DIR','','','aaclcdec_mdw', d)}"
-DISTRO_FEATURES_remove = " ${@bb.utils.contains('XT_RCAR_PROPRIETARY_MULTIMEDIA_DIR','','','use_eva_pkg', d)}"
 
 ASSUME_PROVIDED += "sync-native"
 HOSTTOOLS += "sync"


### PR DESCRIPTION
This PR is just experimental proposal for discussion and was not tested.
=====
Instead of append feature with following conditional removal
we can do just conditional append.

So in this patch we append some multimedia features only
if XT_RCAR_PROPRIETARY_MULTIMEDIA_DIR is provided (not empty).
Also pay attention that white space is made part of 'falsevalue'
intentionaly to avoid appending of whitespace for empty dir.

Signed-off-by: Ruslan Shymkevych <ruslan_shymkevych@epam.com>