### PR TITLE
domd: Avoid resizing of console for SSH connections

### DIFF
--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-core/base-files/base-files_%.bbappend
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-core/base-files/base-files_%.bbappend
@@ -5,6 +5,8 @@ hostname .= "-domd"
 
 do_install_append () {
 	sed -i '/PATH="/a PATH="$PATH:${base_prefix}${XT_DIR_ABS_ROOTFS_SCRIPTS}"' ${D}${sysconfdir}/profile
-	echo "shopt -s checkwinsize" >> ${D}${sysconfdir}/profile
-	echo "resize 1> /dev/null" >> ${D}${sysconfdir}/profile
+	echo "if [[ -z \${SSH_CONNECTION} ]] ; then" >> ${D}${sysconfdir}/profile
+	echo "	shopt -s checkwinsize" >> ${D}${sysconfdir}/profile
+	echo "  resize 1> /dev/null" >> ${D}${sysconfdir}/profile
+	echo "fi" >> ${D}${sysconfdir}/profile
 }


### PR DESCRIPTION
We see that execution of 'resize' affects some applications during
SSH connection. Also this command is used only for interactive console.

This patch is assembly of two patches from meta-xt-prod-tu2019-demo:
ff27d56 Avoid resizing of console for SSH connections
c39cb17 domd: hide '$' from bitbake
Sign-off's are taken from original patches.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>
Signed-off-by: Ruslan Shymkevych <ruslan_shymkevych@epam.com>