### PR TITLE
New GFX pkg does not need header from mesa

### DIFF
--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-graphics/mesa/mesa_%.bbappend
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-graphics/mesa/mesa_%.bbappend
@@ -1,9 +1,0 @@
-# We need this header file to build gles-user-module.
-# Previously it was provided by meta-renesas-rcar-gen3 layer for Qt environment.
-# Recipe location: meta-renesas-rcar-gen3/meta-rcar-gen3/recipes-graphics/mesa/mesa-wayland.inc
-# Since we do not use Qt the header was removed by mesa recipe,
-# so we have to install it manually.
-do_install_append () {
-    install -Dm 644 ${S}/include/EGL/eglmesaext.h ${D}/${includedir}/EGL/eglmesaext.h
-}
-FILES_${PN} += " ${includedir}/EGL/eglmesaext.h"

--- a/recipes-domu/domu-image-weston/files/meta-xt-prod-extra/recipes-graphics/mesa/mesa_%.bbappend
+++ b/recipes-domu/domu-image-weston/files/meta-xt-prod-extra/recipes-graphics/mesa/mesa_%.bbappend
@@ -1,9 +1,0 @@
-# We need this header file to build gles-user-module.
-# Previously it was provided by meta-renesas-rcar-gen3 layer for Qt environment.
-# Recipe location: meta-renesas-rcar-gen3/meta-rcar-gen3/recipes-graphics/mesa/mesa-wayland.inc
-# Since we do not use Qt the header was removed by mesa recipe,
-# so we have to install it manually.
-do_install_append () {
-    install -Dm 644 ${S}/include/EGL/eglmesaext.h ${D}/${includedir}/EGL/eglmesaext.h
-}
-FILES_${PN} += " ${includedir}/EGL/eglmesaext.h"


### PR DESCRIPTION
because it already has the necessary header (EGL/eglwaylandext.h)
in the pkg itself.
The following has been removed 0001-EGL-eglext.h-Include-eglmesaext.h.patch
Modified gles-module-egl-headers.inc

Signed-off-by: Usyk Ihor <ihor_usyk@epam.com>