### PR TITLE
Provide LAYERSERIES_COMPAT_ to layers

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -8,3 +8,5 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 BBFILE_COLLECTIONS += "meta-xt-products"
 BBFILE_PATTERN_meta-xt-products = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-xt-products = "6"
+
+LAYERSERIES_COMPAT_meta-xt-products = "thud"

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/conf/layer.conf
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/conf/layer.conf
@@ -8,3 +8,5 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 BBFILE_COLLECTIONS += "meta-xt-prod-extra"
 BBFILE_PATTERN_meta-xt-prod-extra := "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-xt-prod-extra = "6"
+
+LAYERSERIES_COMPAT_meta-xt-prod-extra = "thud"

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/conf/layer.conf
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/conf/layer.conf
@@ -8,3 +8,5 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 BBFILE_COLLECTIONS += "meta-xt-prod-extra"
 BBFILE_PATTERN_meta-xt-prod-extra := "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-xt-prod-extra = "6"
+
+LAYERSERIES_COMPAT_meta-xt-prod-extra = "thud"

--- a/recipes-domu/domu-image-android/files/meta-xt-prod-extra/conf/layer.conf
+++ b/recipes-domu/domu-image-android/files/meta-xt-prod-extra/conf/layer.conf
@@ -8,3 +8,5 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 BBFILE_COLLECTIONS += "meta-xt-prod-extra"
 BBFILE_PATTERN_meta-xt-prod-extra := "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-xt-prod-extra = "6"
+
+LAYERSERIES_COMPAT_meta-xt-prod-extra = "thud"

--- a/recipes-domu/domu-image-fusion/files/meta-xt-prod-extra/conf/layer.conf
+++ b/recipes-domu/domu-image-fusion/files/meta-xt-prod-extra/conf/layer.conf
@@ -8,3 +8,5 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 BBFILE_COLLECTIONS += "meta-xt-prod-extra"
 BBFILE_PATTERN_meta-xt-prod-extra := "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-xt-prod-extra = "6"
+
+LAYERSERIES_COMPAT_meta-xt-prod-extra = "thud"

--- a/recipes-domu/domu-image-weston/files/meta-xt-prod-extra/conf/layer.conf
+++ b/recipes-domu/domu-image-weston/files/meta-xt-prod-extra/conf/layer.conf
@@ -8,3 +8,5 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 BBFILE_COLLECTIONS += "meta-xt-prod-extra"
 BBFILE_PATTERN_meta-xt-prod-extra := "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-xt-prod-extra = "6"
+
+LAYERSERIES_COMPAT_meta-xt-prod-extra = "thud"


### PR DESCRIPTION
Provide LAYERSERIES_COMPAT_ to layers

Add
LAYERSERIES_COMPAT_meta-xt-prod* = "thud"
to most of layers.

According to Yocto Mega-Manual:
"Setting LAYERSERIES_COMPAT is required by the Yocto Project
Compatible version 2 standard. The OpenEmbedded build system
produces a warning if the variable is not set for any given layer."
Also:
"If a layer sets a value that does not include the current version
("sumo" for the 2.5 release), then an error will be produced."

Pay attention that two layers were skipped as not tested againt thud:
- dom0-image-resque-initramfs
- domu-image-litmusrt

Signed-off-by: Ruslan Shymkevych <ruslan_shymkevych@epam.com>