### PR TITLE
armtf: Update patch in a recipe to avoid WARNING during do_patch

### DIFF
--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-bsp/arm-trusted-firmware/files/0001-rcar-Use-UART-instead-of-Secure-DRAM-area-for-loggin.patch
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-bsp/arm-trusted-firmware/files/0001-rcar-Use-UART-instead-of-Secure-DRAM-area-for-loggin.patch
@@ -1,6 +1,6 @@
-From b199ba985199f0dd56553d1e3fd2a1570317a57a Mon Sep 17 00:00:00 2001
+From 33aca1e42e7431a78945ae54e638b413a5eb2793 Mon Sep 17 00:00:00 2001
 From: Oleksandr Tyshchenko <oleksandr_tyshchenko@epam.com>
-Date: Thu, 28 Sep 2017 13:58:00 +0300
+Date: Thu, 13 Feb 2020 19:34:21 +0200
 Subject: [PATCH] rcar: Use UART instead of Secure DRAM area for logging in
  BL31
 
@@ -36,12 +36,12 @@ index 4178848..a711998 100644
 +endfunc console_uninit
 +
 diff --git a/plat/renesas/rcar/platform.mk b/plat/renesas/rcar/platform.mk
-index 78db0eb..3086f09 100644
+index a8b4672..5ddf035 100644
 --- a/plat/renesas/rcar/platform.mk
 +++ b/plat/renesas/rcar/platform.mk
-@@ -69,7 +69,7 @@ BL31_SOURCES		+=	${RCAR_GIC_SOURCES}				\
- 				plat/renesas/rcar/rcar_pm.c			\
+@@ -70,7 +70,7 @@ BL31_SOURCES		+=	${RCAR_GIC_SOURCES}				\
  				plat/renesas/rcar/rcar_sip_svc.c		\
+ 				plat/renesas/rcar/drivers/board/board.c		\
  				plat/renesas/rcar/drivers/dramconf/dramconf.c	\
 -				plat/renesas/rcar/drivers/memdrv/rcar_console.S	\
 +				plat/renesas/rcar/drivers/scif/scif.S		\


### PR DESCRIPTION
do_patch complains about 0001-rcar-Use-UART-instead-of-Secure-DRAM-area-for-loggin.patch:
"Some of the context lines in patches were ignored. This can lead to
incorrectly applied patches."

Signed-off-by: Oleksandr Tyshchenko <oleksandr_tyshchenko@epam.com>