### PR TITLE
domd: Remove redundant 'rcar' from MACHINEOVERRIDES

### DIFF
--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/doc/local.conf.rcar-domd-image-weston
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/doc/local.conf.rcar-domd-image-weston
@@ -404,7 +404,6 @@ MACHINE_FEATURES_append = " cas"
 
 # For virtualization
 DISTRO_FEATURES_append = " virtualization"
-MACHINEOVERRIDES .= ":rcar"
 
 DISTRO_FEATURES_remove = " x11 gtk gobject-introspection-data nfc irda zeroconf 3g"
 


### PR DESCRIPTION
We add 'rcar' to MACHINEOVERRIDES for every machine described in
meta-xt-images/machine/meta-xt-images-rcar-gen3/conf/machine

So there is no need to duplicate 'rcar' as far as this results in
additional search path during fetch step.

Signed-off-by: Ruslan Shymkevych <ruslan_shymkevych@epam.com>