### PR TITLE
doma: Decrease init logs verbosity

### DIFF
--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/doma-salvator-generic.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/doma-salvator-generic.cfg
@@ -32,7 +32,7 @@ disk = [
 ]
 
 # Kernel command line options
-extra = "ip=dhcp root=/dev/xvda1 androidboot.hardware=xenvm skip_initramfs init=/init ro rootwait console=hvc0 cma=256M@1-2G printk.devkmsg=on androidboot.selinux=permissive pvrsrvkm.DriverMode=1 androidboot.android_dt_dir=/proc/device-tree/firmware#1/android/ xt_page_pool=2097152 xt_cma=4194304"
+extra = "ip=dhcp root=/dev/xvda1 androidboot.hardware=xenvm skip_initramfs init=/init ro rootwait console=hvc0 cma=256M@1-2G androidboot.selinux=permissive pvrsrvkm.DriverMode=1 androidboot.android_dt_dir=/proc/device-tree/firmware#1/android/ xt_page_pool=2097152 xt_cma=4194304"
 
 # Initial memory allocation (MB)
 memory = 2160

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/doma-salvator-x-h3-4x2g.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/doma-salvator-x-h3-4x2g.cfg
@@ -39,7 +39,7 @@ disk = [
 ]
 
 # Kernel command line options
-extra = "ip=dhcp root=/dev/xvda1 androidboot.hardware=xenvm skip_initramfs init=/init ro rootwait console=hvc0 cma=256M@1-2G printk.devkmsg=on androidboot.selinux=permissive pvrsrvkm.DriverMode=1 androidboot.android_dt_dir=/proc/device-tree/firmware#1/android/ xt_page_pool=2097152 xt_cma=4194304"
+extra = "ip=dhcp root=/dev/xvda1 androidboot.hardware=xenvm skip_initramfs init=/init ro rootwait console=hvc0 cma=256M@1-2G androidboot.selinux=permissive pvrsrvkm.DriverMode=1 androidboot.android_dt_dir=/proc/device-tree/firmware#1/android/ xt_page_pool=2097152 xt_cma=4194304"
 
 # Initial memory allocation (MB)
 memory = 6032


### PR DESCRIPTION
printk.devkmsg=on was added for debugging purposes and
needed for init specific use-cases.

Signed-off-by: Andrii Chepurnyi <andrii_chepurnyi@epam.com>