### PR TITLE
[Do not merge until agreed] Enable PV Camera support

### DIFF
--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/doc/local.conf.dom0-image-minimal-initramfs
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/doc/local.conf.dom0-image-minimal-initramfs
@@ -223,7 +223,7 @@ DISTRO_FEATURES_append = " virtualization"
 DISTRO_FEATURES_append = " xen"
 
 # Configuration for Para-virtual camera
-#DISTRO_FEATURES_append = " pvcamera"
+DISTRO_FEATURES_append = " pvcamera"
 
 DEPLOY_DIR = "${TMPDIR}/deploy"
 IMAGE_ROOTFS = "${TMPDIR}/rootfs"

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/doc/local.conf.rcar-domd-image-weston
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/doc/local.conf.rcar-domd-image-weston
@@ -407,7 +407,7 @@ MACHINE_FEATURES_append = " cas"
 DISTRO_FEATURES_append = " virtualization"
 
 # Configuration for Para-virtual camera
-#DISTRO_FEATURES_append = " pvcamera"
+DISTRO_FEATURES_append = " pvcamera"
 
 DISTRO_FEATURES_remove = " x11 gtk gobject-introspection-data nfc irda zeroconf 3g"
 


### PR DESCRIPTION
As per default settings in guest domain and media pipeline
configuration files the "HDMI_IN Camera" will be used.

Signed-off-by: Oleksandr Tyshchenko <oleksandr_tyshchenko@epam.com>