### PR TITLE
Remove Java build support for Android

### DIFF
--- a/recipes-domu/domu-image-android/files/meta-xt-prod-extra/doc/bblayers.conf.domu-image-android
+++ b/recipes-domu/domu-image-android/files/meta-xt-prod-extra/doc/bblayers.conf.domu-image-android
@@ -8,7 +8,6 @@ BBFILES ?= ""
 BBLAYERS ?= " \
   ${TOPDIR}/../poky/meta \
   ${TOPDIR}/../poky/meta-poky \
-  ${TOPDIR}/../meta-java \
   ${TOPDIR}/../meta-openembedded/meta-oe \
   ${TOPDIR}/../meta-openembedded/meta-python \
 "

--- a/recipes-domu/domu-image-android/files/meta-xt-prod-extra/doc/local.conf.domu-image-android
+++ b/recipes-domu/domu-image-android/files/meta-xt-prod-extra/doc/local.conf.domu-image-android
@@ -209,15 +209,6 @@ CONF_VERSION = "1"
 BB_DANGLINGAPPENDS_WARNONLY = "yes"
 DISTRO_FEATURES = ""
 
-# Possible provider: cacao-initial-native and jamvm-initial-native
-PREFERRED_PROVIDER_virtual/java-initial-native = "cacao-initial-native"
-
-# Possible provider: cacao-native and jamvm-native
-PREFERRED_PROVIDER_virtual/java-native = "cacao-native"
-
-# Optional since there is only one provider for now
-PREFERRED_PROVIDER_virtual/javac-native = "ecj-bootstrap-native"
-
 ASSUME_PROVIDED += "repo-native"
 HOSTTOOLS += "repo"
 


### PR DESCRIPTION
 doma: Remove Java support for Android

Android uses internal tools for the build. There is
no need to provide external JVM/JDK for the build.