### PR TITLE
domd: domu: Remove default value of XT_PRODUCT_NAME

### DIFF
--- a/recipes-domd/domd-image-weston/domd-image-weston.bbappend
+++ b/recipes-domd/domd-image-weston/domd-image-weston.bbappend
@@ -2,8 +2,6 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 FILESEXTRAPATHS_prepend := "${THISDIR}/../../inc:"
 FILESEXTRAPATHS_prepend := "${THISDIR}/../../recipes-domx:"
 
-XT_PRODUCT_NAME ?= "prod-devel"
-
 python __anonymous () {
     product_name = d.getVar('XT_PRODUCT_NAME', True)
     folder_name = product_name.replace("-", "_")

--- a/recipes-domu/domu-image-weston/domu-image-weston.bbappend
+++ b/recipes-domu/domu-image-weston/domu-image-weston.bbappend
@@ -4,8 +4,6 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/../../recipes-domx:"
 
 do_configure[depends] += "domd-image-weston:do_domd_install_machine_overrides"
 
-XT_PRODUCT_NAME ?= "prod-devel"
-
 python __anonymous () {
     product_name = d.getVar('XT_PRODUCT_NAME', True)
     folder_name = product_name.replace("-", "_")


### PR DESCRIPTION
Usage of default value for XT_PRODUCT_NAME has few negative results:
- possible usage of manifest from incorrect folder and hard to find errors
- misleading info during read of recipe especially for forked products

Taking into account above mentioned it's better to get build error
on early stage than correct build with incorrect manifest.

Signed-off-by: Ruslan Shymkevych <ruslan_shymkevych@epam.com>