### PR TITLE
Remove BBLAYERS_NON_REMOVABLE

### DIFF
--- a/recipes-dom0/dom0-image-rescue-initramfs/files/meta-xt-prod-extra/doc/bblayers.conf.dom0-image-rescue-initramfs
+++ b/recipes-dom0/dom0-image-rescue-initramfs/files/meta-xt-prod-extra/doc/bblayers.conf.dom0-image-rescue-initramfs
@@ -14,8 +14,3 @@ BBLAYERS ?= " \
   ${TOPDIR}/../meta-openembedded/meta-networking \
   ${TOPDIR}/../meta-openembedded/meta-python \
 "
-
-BBLAYERS_NON_REMOVABLE ?= " \
-  ${TOPDIR}/../poky/meta \
-  ${TOPDIR}/../poky/meta-poky \
-"

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/doc/bblayers.conf.dom0-image-minimal-initramfs
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/doc/bblayers.conf.dom0-image-minimal-initramfs
@@ -16,8 +16,3 @@ BBLAYERS ?= " \
   ${TOPDIR}/../meta-openembedded/meta-filesystems \
   ${TOPDIR}/../meta-virtualization \
 "
-
-BBLAYERS_NON_REMOVABLE ?= " \
-  ${TOPDIR}/../poky/meta \
-  ${TOPDIR}/../poky/meta-poky \
-"

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/doc/bblayers.conf.rcar-domd-image-weston
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/doc/bblayers.conf.rcar-domd-image-weston
@@ -19,7 +19,3 @@ BBLAYERS ?= " \
   ${TOPDIR}/../meta-virtualization \
   ${TOPDIR}/../meta-clang \
   "
-BBLAYERS_NON_REMOVABLE ?= " \
-  ${TOPDIR}/../poky/meta \
-  ${TOPDIR}/../poky/meta-poky \
-  "

--- a/recipes-domu/domu-image-android/files/meta-xt-prod-extra/doc/bblayers.conf.domu-image-android
+++ b/recipes-domu/domu-image-android/files/meta-xt-prod-extra/doc/bblayers.conf.domu-image-android
@@ -11,8 +11,3 @@ BBLAYERS ?= " \
   ${TOPDIR}/../meta-openembedded/meta-oe \
   ${TOPDIR}/../meta-openembedded/meta-python \
 "
-
-BBLAYERS_NON_REMOVABLE ?= " \
-  ${TOPDIR}/../poky/meta \
-  ${TOPDIR}/../poky/meta-poky \
-"

--- a/recipes-domu/domu-image-fusion/files/meta-xt-prod-extra/doc/bblayers.conf.domf-image-minimal
+++ b/recipes-domu/domu-image-fusion/files/meta-xt-prod-extra/doc/bblayers.conf.domf-image-minimal
@@ -15,8 +15,3 @@ BBLAYERS ?= " \
   ${TOPDIR}/../meta-openembedded/meta-filesystems \
   ${TOPDIR}/../meta-golang \
 "
-
-BBLAYERS_NON_REMOVABLE ?= " \
-  ${TOPDIR}/../poky/meta \
-  ${TOPDIR}/../poky/meta-poky \
-"

--- a/recipes-domu/domu-image-weston/files/meta-xt-prod-extra/doc/bblayers.conf.rcar-domu-image-weston
+++ b/recipes-domu/domu-image-weston/files/meta-xt-prod-extra/doc/bblayers.conf.rcar-domu-image-weston
@@ -16,7 +16,3 @@ BBLAYERS ?= " \
   ${TOPDIR}/../meta-openembedded/meta-python \
   ${TOPDIR}/../meta-clang \
   "
-BBLAYERS_NON_REMOVABLE ?= " \
-  ${TOPDIR}/../poky/meta \
-  ${TOPDIR}/../poky/meta-poky \
-  "


### PR DESCRIPTION
BBLAYERS_NON_REMOVABLE was used only by Hob.
This variable was removed from yocto in March 2016 and
there is no reason for us to keep it.

Signed-off-by: Ruslan Shymkevych <ruslan_shymkevych@epam.com>