### PR TITLE
Removing support of process_p2m_lookup

### DIFF
--- a/inc/xen-version.inc
+++ b/inc/xen-version.inc
@@ -5,4 +5,4 @@
 ################################################################################
 require ../meta-xt-images-domx/recipes-extended/xen/xen-4.13-thud.inc
 
-SRC_URI = "git://github.com/xen-troops/xen.git;protocol=https;branch=RELEASE-4.13.0-xt0.1.prod-devel"
+SRC_URI = "git://github.com/xen-troops/xen.git;protocol=https;branch=RELEASE-4.13.0-xt0.2.prod-devel"

--- a/recipes-dom0/dom0-image-thin-initramfs/dom0-image-thin-initramfs.bbappend
+++ b/recipes-dom0/dom0-image-thin-initramfs/dom0-image-thin-initramfs.bbappend
@@ -8,6 +8,13 @@ XT_GUESTS_BUILD ?= "doma"
 XT_GUESTS_INSTALL ?= "doma"
 
 python __anonymous () {
+    machine = d.getVar('MACHINE', True)
+    not_supported_machines = ["salvator-x-m3", "salvator-xs-h3", "h3ulcb", "m3ulcb", "salvator-x-h3"]
+    if machine in not_supported_machines:
+        warning = 'The machine {} is not supported.'.format(machine) 
+        bb.warn(warning)
+        bb.fatal("Use branch prod-process-p2m-lookup of prod-devel to suupport.")
+
     guests = d.getVar('XT_GUESTS_BUILD', True).split()
     if "doma" in guests :
         d.appendVarFlag("do_compile", "depends", " domu-image-android:do_${BB_DEFAULT_TASK} ")

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-kernel/kernel-module-gles/kernel-module-gles_1.11.bbappend
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-kernel/kernel-module-gles/kernel-module-gles_1.11.bbappend
@@ -2,7 +2,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 require inc/xt_shared_env.inc
 
 PVRKM_URL = "git://git@gitpct.epam.com/epmd-aepr/pvr_km_vgpu_img.git"
-BRANCH = "1.11/5516664"
+BRANCH = "1.11/5516664-1"
 SRCREV = "${AUTOREV}"
 
 # W/A fix build errors with GCC 8.1

--- a/recipes-domu/domu-image-weston/files/meta-xt-prod-extra/recipes-kernel/kernel-module-gles/kernel-module-gles_1.11.bbappend
+++ b/recipes-domu/domu-image-weston/files/meta-xt-prod-extra/recipes-kernel/kernel-module-gles/kernel-module-gles_1.11.bbappend
@@ -2,7 +2,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 require inc/xt_shared_env.inc
 
 PVRKM_URL = "git://git@gitpct.epam.com/epmd-aepr/pvr_km_vgpu_img.git"
-BRANCH = "1.11/5516664"
+BRANCH = "1.11/5516664-1"
 SRCREV = "${AUTOREV}"
 
 # W/A fix build errors with GCC 8.1


### PR DESCRIPTION
The branch of xen is reconfigured at RELEASE-4.13.0-xt0.2.prod-devel
The feature process_p2m_lookup has been reverted from the RELEASE-4.13.0-xt0.2.prod-devel
Some machines do not work now, there are
salvator-x-m3, salvator-xs-h3, h3ulcb, m3ulcb, salvator-x-h3

In a case, if local.conf has one of the mentioned machines as current one,
the warning and valid branch of prod-devel prod-process-p2m-lookupare displayed.

Signed-off-by: Ihor Usyk <ihor_usyk@epam.com>