### PR TITLE
Switch to Xen v4.14 release

### DIFF
--- a/inc/xen-version.inc
+++ b/inc/xen-version.inc
@@ -3,6 +3,6 @@
 # Following inc file defines XEN version and needed glue info to get it
 # built with the current yocto version
 ################################################################################
-require ../meta-xt-images-domx/recipes-extended/xen/xen-4.13-thud.inc
+require ../meta-xt-images-domx/recipes-extended/xen/xen-4.14-thud.inc
 
-SRC_URI = "git://github.com/xen-troops/xen.git;protocol=https;branch=RELEASE-4.13.0-xt0.2.prod-devel"
+SRC_URI = "git://github.com/xen-troops/xen.git;protocol=https;branch=xen-4.14rc-migration"

--- a/recipes-dom0/dom0-image-thin-initramfs/dom0-image-thin-initramfs.bbappend
+++ b/recipes-dom0/dom0-image-thin-initramfs/dom0-image-thin-initramfs.bbappend
@@ -61,7 +61,7 @@ add_to_local_conf() {
     # direct call to getty with hvc0 is installed into inittab by meta-viltualization.
     base_update_conf_value ${local_conf} SERIAL_CONSOLE ""
 
-    base_update_conf_value ${local_conf} PREFERRED_VERSION_xen "4.13.0+git\%"
+    base_update_conf_value ${local_conf} PREFERRED_VERSION_xen "4.14.0+git\%"
 
     base_update_conf_value ${local_conf} XT_GUESTS_INSTALL "${XT_GUESTS_INSTALL}"
 }

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-core/images/core-image-thin-initramfs.bbappend
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-core/images/core-image-thin-initramfs.bbappend
@@ -7,6 +7,7 @@ IMAGE_INSTALL_append = " \
     xen-xencommons \
     xen-xenstat \
     xen-misc \
+    xen-xenhypfs \
     dom0 \
     dom0-run-vcpu_pin \
     dom0-run-set_root_dev \

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/xen/files/0001-libxl-Add-DTB-compatible-list-to-config-file.patch
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/xen/files/0001-libxl-Add-DTB-compatible-list-to-config-file.patch
@@ -18,10 +18,10 @@ Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>
  3 files changed, 42 insertions(+), 8 deletions(-)
 
 diff --git a/tools/libxl/libxl_arm.c b/tools/libxl/libxl_arm.c
-index 94eb54f..2ac1234 100644
+index e70acc5..4225cf6 100644
 --- a/tools/libxl/libxl_arm.c
 +++ b/tools/libxl/libxl_arm.c
-@@ -270,20 +270,46 @@ static int fdt_property_regs(libxl__gc *gc, void *fdt,
+@@ -278,20 +278,46 @@ static int fdt_property_regs(libxl__gc *gc, void *fdt,
  
  static int make_root_properties(libxl__gc *gc,
                                  const libxl_version_info *vers,
@@ -75,7 +75,7 @@ index 94eb54f..2ac1234 100644
      if (res) return res;
  
      res = fdt_property_cell(fdt, "interrupt-parent", GUEST_PHANDLE_GIC);
-@@ -930,7 +956,7 @@ next_resize:
+@@ -938,7 +964,7 @@ next_resize:
  
          FDT( fdt_begin_node(fdt, "") );
  
@@ -85,10 +85,10 @@ index 94eb54f..2ac1234 100644
          FDT( make_cpus_node(gc, fdt, info->max_vcpus, ainfo) );
          FDT( make_psci_node(gc, fdt) );
 diff --git a/tools/libxl/libxl_types.idl b/tools/libxl/libxl_types.idl
-index 5c02fb1..0af8852 100644
+index 679dac6..2505220 100644
 --- a/tools/libxl/libxl_types.idl
 +++ b/tools/libxl/libxl_types.idl
-@@ -543,6 +543,7 @@ libxl_domain_build_info = Struct("domain_build_info",[
+@@ -550,6 +550,7 @@ libxl_domain_build_info = Struct("domain_build_info",[
      # Note that the partial device tree should avoid to use the phandle
      # 65000 which is reserved by the toolstack.
      ("device_tree",      string),
@@ -97,10 +97,10 @@ index 5c02fb1..0af8852 100644
      ("bootloader",       string),
      ("bootloader_args",  libxl_string_list),
 diff --git a/tools/xl/xl_parse.c b/tools/xl/xl_parse.c
-index 640c6ae..d6f7b03 100644
+index 1e6871a..863c6ee 100644
 --- a/tools/xl/xl_parse.c
 +++ b/tools/xl/xl_parse.c
-@@ -2405,6 +2405,13 @@ skip_vfb:
+@@ -2663,6 +2663,13 @@ skip_vfb:
          }
      }
  

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/xen/files/0002-libxl-Add-DTB-passthrough-nodes-list.patch
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/xen/files/0002-libxl-Add-DTB-passthrough-nodes-list.patch
@@ -20,10 +20,10 @@ Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>
  3 files changed, 24 insertions(+), 4 deletions(-)
 
 diff --git a/tools/libxl/libxl_arm.c b/tools/libxl/libxl_arm.c
-index 2ac1234..e32ed15 100644
+index 4225cf6..1e9f04c 100644
 --- a/tools/libxl/libxl_arm.c
 +++ b/tools/libxl/libxl_arm.c
-@@ -835,9 +835,10 @@ static int copy_node_by_path(libxl__gc *gc, const char *path,
+@@ -843,9 +843,10 @@ static int copy_node_by_path(libxl__gc *gc, const char *path,
   *  - /passthrough node
   *  - /aliases node
   */
@@ -36,7 +36,7 @@ index 2ac1234..e32ed15 100644
  
      r = copy_node_by_path(gc, "/passthrough", fdt, pfdt);
      if (r < 0) {
-@@ -851,6 +852,16 @@ static int copy_partial_fdt(libxl__gc *gc, void *fdt, void *pfdt)
+@@ -859,6 +860,16 @@ static int copy_partial_fdt(libxl__gc *gc, void *fdt, void *pfdt)
          return r;
      }
  
@@ -53,7 +53,7 @@ index 2ac1234..e32ed15 100644
      return 0;
  }
  
-@@ -863,7 +874,8 @@ static int check_partial_fdt(libxl__gc *gc, void *fdt, size_t size)
+@@ -871,7 +882,8 @@ static int check_partial_fdt(libxl__gc *gc, void *fdt, size_t size)
      return ERROR_FAIL;
  }
  
@@ -63,7 +63,7 @@ index 2ac1234..e32ed15 100644
  {
      /*
       * We should never be here when the partial device tree is not
-@@ -989,7 +1001,7 @@ next_resize:
+@@ -997,7 +1009,7 @@ next_resize:
              FDT( make_optee_node(gc, fdt) );
  
          if (pfdt)
@@ -73,10 +73,10 @@ index 2ac1234..e32ed15 100644
          FDT( fdt_end_node(fdt) );
  
 diff --git a/tools/libxl/libxl_types.idl b/tools/libxl/libxl_types.idl
-index 0af8852..92b989e 100644
+index 2505220..90425f1 100644
 --- a/tools/libxl/libxl_types.idl
 +++ b/tools/libxl/libxl_types.idl
-@@ -544,6 +544,7 @@ libxl_domain_build_info = Struct("domain_build_info",[
+@@ -551,6 +551,7 @@ libxl_domain_build_info = Struct("domain_build_info",[
      # 65000 which is reserved by the toolstack.
      ("device_tree",      string),
      ("dt_compatible",    libxl_string_list),
@@ -85,10 +85,10 @@ index 0af8852..92b989e 100644
      ("bootloader",       string),
      ("bootloader_args",  libxl_string_list),
 diff --git a/tools/xl/xl_parse.c b/tools/xl/xl_parse.c
-index d6f7b03..2dc72b5 100644
+index 863c6ee..6c00d16 100644
 --- a/tools/xl/xl_parse.c
 +++ b/tools/xl/xl_parse.c
-@@ -2412,6 +2412,13 @@ skip_vfb:
+@@ -2670,6 +2670,13 @@ skip_vfb:
              exit(-ERROR_FAIL);
      }
  

--- a/recipes-domd/domd-image-weston/domd-image-weston.bbappend
+++ b/recipes-domd/domd-image-weston/domd-image-weston.bbappend
@@ -98,7 +98,7 @@ configure_versions_rcar() {
     local local_conf="${S}/build/conf/local.conf"
 
     cd ${S}
-    base_update_conf_value ${local_conf} PREFERRED_VERSION_xen "4.13.0+git\%"
+    base_update_conf_value ${local_conf} PREFERRED_VERSION_xen "4.14.0+git\%"
     base_update_conf_value ${local_conf} PREFERRED_VERSION_u-boot_rcar "v2018.09\%"
     if [ -z ${XT_RCAR_EVAPROPRIETARY_DIR} ];then
         base_update_conf_value ${local_conf} PREFERRED_PROVIDER_gles-user-module "gles-user-module"

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-extended/xen/xen_git.bbappend
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-extended/xen/xen_git.bbappend
@@ -28,13 +28,7 @@ FILES_${PN}-flask = " \
 "
 
 do_configure_append() {
-    export XEN_CONFIG_EXPERT=y
-
     oe_runmake xt_defconfig
-}
-
-do_compile_prepend () {
-    export XEN_CONFIG_EXPERT=y
 }
 
 do_deploy_append_rcar () {


### PR DESCRIPTION
The one important thing here is that now EXPERT mode can be selected
from the menuconfig directly.
There is no need to use XEN_CONFIG_EXPERT=y on the make command line
anymore.

Also install xenhypfs tool.

Signed-off-by: Oleksandr Tyshchenko <oleksandr_tyshchenko@epam.com>