### PR TITLE
doma: audio: Declare support for required sample rates

### DIFF
--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/doma-vdevices.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/doma-vdevices.cfg
@@ -20,8 +20,8 @@ vdispl = [ 'backend=DomD, be-alloc=0, connectors=2000:1920x1080;2001:1024x576' ]
 vkb = [ 'backend=DomD, backend-type=linux, multi-touch-width=1920, multi-touch-height=1080, multi-touch-num-contacts=10, feature-disable-keyboard=1, unique-id=T:2000',
         'backend=DomD, backend-type=linux, multi-touch-width=1024, multi-touch-height=576, multi-touch-num-contacts=10, feature-disable-keyboard=1, unique-id=T:2001' ]
 
-vsnd = [[ 'card, backend=DomD, buffer-size=65536, short-name=VCard, long-name=Virtual sound card, sample-rates=48000, sample-formats=s16_le',
-          'pcm, name=dev1', 'stream, unique-id=pulse, type=P', 'stream, unique-id=pulse, type=C, sample-rates=8000;11025;12000;16000;22050;24000;32000;44100;48000',
+vsnd = [[ 'card, backend=DomD, buffer-size=65536, short-name=VCard, long-name=Virtual sound card, sample-rates=8000;11025;16000;22050;32000;44100;48000, sample-formats=s16_le',
+          'pcm, name=dev1', 'stream, unique-id=pulse, type=P', 'stream, unique-id=pulse, type=C',
           'pcm, name=dev2', 'stream, unique-id=pulse, type=P',
           'pcm, name=dev3', 'stream, unique-id=pulse, type=P',
           'pcm, name=dev4', 'stream, unique-id=pulse, type=P',


### PR DESCRIPTION
According to Android's CDD we need to support following sample rates
for playback and record:
8000, 11025, 16000, 22050, 32000, 44100, 48000

Remove 24000 as not supported.

Signed-off-by: Ruslan Shymkevych <ruslan_shymkevych@epam.com>