### PR TITLE
Switch android_manifest branch at android-10.0.0_r3-master-unsafe

### DIFF
--- a/recipes-domu/domu-image-android/files/meta-xt-prod-extra/recipes-extended/android/android.bbappend
+++ b/recipes-domu/domu-image-android/files/meta-xt-prod-extra/recipes-extended/android/android.bbappend
@@ -3,7 +3,7 @@ SRCREV = "${AUTOREV}"
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
 SRC_URI_append = " \
-    repo://github.com/xen-troops/android_manifest;protocol=https;branch=android-10.0.0_r3-master;manifest=doma.xml;scmdata=keep "
+    repo://github.com/xen-troops/android_manifest;protocol=https;branch=android-10.0.0_r3-master-unsafe;manifest=doma.xml;scmdata=keep "
 
 # put it out of the source tree, so it can be reused after cleanup
 ANDROID_OUT_DIR_COMMON_BASE = "${SSTATE_DIR}/../${ANDROID_PRODUCT}-${SOC_FAMILY}"


### PR DESCRIPTION
The commit to support p2m lookup has been reverted from master. As result-
some machines are not supported anymore (in main branch). It has been decided
to create a separate branch for prod-devel to leave the possibility to handle
the old behavior. The master of android_manifest contains the reference at 'cleaned'
pvr_km_vgpu_img, this is because the branch android-10.0.0_r3-master-unsafe has been created
to have the reference at 'not cleaned' pvr_km_vgpu_img.

Signed-off-by: Ihor Usyk <ihor_usyk@epam.com>

> Not correct patch description, since it is not cleaned branch

Here is an explanation  -why the branch has been created. The description has the information that this branch supports 'not cleaned' pvr_km_vgpu_img: "his is because the branch android-10.0.0_r3-master-unsafe has been created
to have the reference at 'not cleaned' pvr_km_vgpu_img."