### PR TITLE
Revert "Wrap usage of proprietary graphics binaries in domd/domu"

### DIFF
--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-graphics/rcar-proprietary-graphic/rcar-proprietary-graphic.bb
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-graphics/rcar-proprietary-graphic/rcar-proprietary-graphic.bb
@@ -1,7 +1,4 @@
 
 require recipes-graphics/gles-module/rcar-proprietary-graphic.inc
 
-python __anonymous () {
-    if d.getVar("XT_RCAR_EVAPROPRIETARY_DIR", True):
-        d.setVar("SRC_URI", "file://rcar-proprietary-graphic-${MACHINE}-domd.tar.gz")
-}
+SRC_URI = "file://rcar-proprietary-graphic-${MACHINE}-domd.tar.gz"

--- a/recipes-domu/domu-image-weston/files/meta-xt-prod-extra/recipes-graphics/rcar-proprietary-graphic/rcar-proprietary-graphic.bb
+++ b/recipes-domu/domu-image-weston/files/meta-xt-prod-extra/recipes-graphics/rcar-proprietary-graphic/rcar-proprietary-graphic.bb
@@ -1,7 +1,5 @@
 
 require recipes-graphics/gles-module/rcar-proprietary-graphic.inc
 
-python __anonymous () {
-    if d.getVar("XT_RCAR_EVAPROPRIETARY_DIR", True):
-        d.setVar("SRC_URI", "file://rcar-proprietary-graphic-${MACHINE}-domu.tar.gz")
-}
+SRC_URI = "file://rcar-proprietary-graphic-${MACHINE}-domu.tar.gz"
+


### PR DESCRIPTION
This reverts commit 48607110cdf3f4aabb52d4d78ad403588be975e7.

Variable XT_RCAR_EVAPROPRIETARY_DIR, used in reverted patch,
is not available indomain's local.conf.
Also patch was not tested deep enough despite comments in PR.