### PR TITLE
Place u-boot in to Initramfs

### DIFF
--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -1,0 +1,26 @@
+require inc/xt_shared_env.inc
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+GUEST_DOMA = "${@bb.utils.contains('XT_GUESTS_INSTALL', 'doma', 'doma', '', d)}"
+
+UBOOT_CONFIG[doma] = "xenguest_arm64_android_defconfig"
+UBOOT_CONFIG_prepend = "${GUEST_DOMA} "
+
+SRCREV = "${AUTOREV}"
+SRC_URI = "\
+    git://github.com/xen-troops/u-boot.git;protocol=https;branch=android-master; \
+"
+
+FILES_${PN} += " \
+    ${@bb.utils.contains('XT_GUESTS_INSTALL', 'doma', '${XT_DIR_ABS_ROOTFS_DOMA}', '', d)} \
+"
+do_install_append() {
+    for dom in ${XT_GUESTS_INSTALL}; do
+        if [ "${dom}" = "doma" ]; then
+           install -d ${D}/${XT_DIR_ABS_ROOTFS_DOMA}
+           install -m 0744 ${D}/boot/u-boot-${GUEST_DOMA}-${PV}-${PR}.${UBOOT_SUFFIX}  ${D}/${XT_DIR_ABS_ROOTFS_DOMA}/${UBOOT_BINARY}
+           rm -f ${D}/boot/u-boot-${GUEST_DOMA}-${PV}-${PR}.${UBOOT_SUFFIX}
+        fi
+    done
+}

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-core/images/core-image-thin-initramfs.bbappend
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-core/images/core-image-thin-initramfs.bbappend
@@ -1,4 +1,4 @@
-DEPENDS += "u-boot-mkimage-native"
+DEPENDS += "${@bb.utils.contains('XT_GUESTS_INSTALL', 'doma', 'u-boot', '', d)} u-boot-mkimage-native"
 
 inherit deploy
 
@@ -14,6 +14,7 @@ IMAGE_INSTALL_append = " \
     domd \
     domd-run \
     domd-install-artifacts \
+    ${@bb.utils.contains('XT_GUESTS_INSTALL', 'doma', 'u-boot', '', d)} \
 "
 
 XT_GUESTS_INSTALL ?= "doma domf"
@@ -21,7 +22,7 @@ XT_GUESTS_INSTALL ?= "doma domf"
 python __anonymous () {
     guests = d.getVar("XT_GUESTS_INSTALL", True).split()
     if "doma" in guests :
-        d.appendVar("IMAGE_INSTALL", " doma doma-run doma-install-artifacts")
+        d.appendVar("IMAGE_INSTALL", " doma doma-run")
     if "domf" in guests :
         d.appendVar("IMAGE_INSTALL", " domf domf-run domf-install-artifacts")
     if "domr" in guests :

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/doma-generic-h3-4x2g.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/doma-generic-h3-4x2g.cfg
@@ -4,7 +4,7 @@ seclabel='system_u:system_r:domU_t'
 name = "DomA"
 
 # Kernel image to boot
-kernel = "/xt/doma/Image"
+kernel = "/xt/doma/u-boot.bin"
 
 device_tree = "/xt/domd/doma.dtb"
 

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/doma-generic-h3.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/doma-generic-h3.cfg
@@ -4,7 +4,7 @@ seclabel='system_u:system_r:domU_t'
 name = "DomA"
 
 # Kernel image to boot
-kernel = "/xt/doma/Image"
+kernel = "/xt/doma/u-boot.bin"
 
 device_tree = "/xt/domd/doma.dtb"
 


### PR DESCRIPTION
1.Remove a "coping" of the DomA Linux kernel into DOM0 initramfs
The following files were modified to change the kernel publishing at u-boot.bin
-doma-generic-h3-4x2g.cfg
-doma-generic-h3.cfg
2.Build a u-boot during the Dom0 build from https://github.com/xen-troops/u-boot (as for the proof of concept this branch: https://github.com/arminn/u-boot/commits/mr_rcar_pvblock should be used).
-The new recipe u-boot_%.bbappend has been added with the corresponded SRC_URI
-core-image-thin-initramfs.bbappend has been modified to build the u-boot.
3.Copy u-boot.bin into DOM0 initramfs
core-image-thin-initramfs.bbappend has been modified to add the u-boot into image installation

Signed-off-by: Ihor Usyk <ihor_usyk@epam.com>