### PR TITLE
INSTALL.txt: Add the packages to support android build

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -7,9 +7,11 @@ Prerequisites:
                     gnupg flex bison gperf build-essential zip curl zlib1g-dev \
                     gcc-multilib g++-multilib libc6-dev-i386 lib32ncurses5-dev \
                     x11proto-core-dev libx11-dev lib32z-dev ccache libgl1-mesa-dev \
-                    libxml2-utils xsltproc unzip python-clang-5.0 gcc-5 g++-5 bc -y
-2. Download and install Google repo: https://source.android.com/setup/build/downloading#installing-repo
-3. Checked with Python v 2.7.12, but other should also work
+                    libxml2-utils xsltproc unzip python-clang-5.0 gcc-5 g++-5 bc \
+                    python3-pyelftools python-pip gcc-aarch64-linux-gnu -y
+2. Install package pycryptodome: sudo pip install pycryptodomex
+3. Download and install Google repo: https://source.android.com/setup/build/downloading#installing-repo
+4. Checked with Python v 2.7.12, but other should also work
 
 About:
 ======


### PR DESCRIPTION
The following packages must be pre-installed
pyelftools
pycryptodomex
gcc-aarch64-linux-gnu

Signed-off-by: Ihor Usyk <ihor_usyk@epam.com>