### PR TITLE
Set linux version 4.14

### DIFF
--- a/recipes-domu/domu-image-android/files/meta-xt-prod-extra/recipes-kernel/linux-libc-headers/linux-libc-headers_%.bbappend
+++ b/recipes-domu/domu-image-android/files/meta-xt-prod-extra/recipes-kernel/linux-libc-headers/linux-libc-headers_%.bbappend
@@ -1,0 +1,5 @@
+RENESAS_BSP_URL = "git://github.com/xen-troops/linux.git"
+
+BRANCH = "v4.14.75-ltsi/rcar-3.9.6-xt0.1"
+SRCREV = "${AUTOREV}"
+LINUX_VERSION = "4.14.75"


### PR DESCRIPTION
The libgcc library is required for the build of optee-os.
Use Linux kernel v4.14.75 to compile libgcc

Signed-off-by: Ihor Usyk <ihor_usyk@epam.com>