### PR TITLE
doc: Increase size of tee.bin written into eMMC

### DIFF
--- a/doc/u-boot-env.txt
+++ b/doc/u-boot-env.txt
@@ -114,7 +114,7 @@ setenv flash_bl2 'tftp 0x48000000 bl2.bin; mmc dev 1 1; mmc write 0x48000000 0x1
 setenv flash_bl31 'tftp 0x48000000 bl31.bin; mmc dev 1 1; mmc write 0x48000000 0x200 0xE00;'
 setenv flash_bootparam_sa0 'tftp 0x48000000 bootparam_sa0.bin; mmc dev 1 1; mmc write 0x48000000 0x0 0x1E;'
 setenv flash_cert_header_sa6 'tftp 0x48000000 cert_header_sa6_emmc.bin; mmc dev 1 1; mmc write 0x48000000 0x180 0x80;'
-setenv flash_tee 'tftp 0x48000000 tee.bin; mmc dev 1 1; mmc write 0x48000000 0x1000 0x400;'
+setenv flash_tee 'tftp 0x48000000 tee.bin; mmc dev 1 1; mmc write 0x48000000 0x1000 0x500;'
 setenv flash_u_boot 'tftp 0x48000000 u-boot.bin; mmc dev 1 2; mmc write 0x48000000 0x0 0x800;'
 setenv flash_z_loaders 'run flash_bootparam_sa0; run flash_bl2; run flash_cert_header_sa6; run flash_bl31; run flash_tee; run flash_u_boot;'
 


### PR DESCRIPTION
After upgrade to OP-TEE 3.9 filesize of tee.bin became bigger
than 512KB, and we need to use appropriate value for writting
into eMMC.

Signed-off-by: Ruslan Shymkevych <ruslan_shymkevych@epam.com>