### PR TITLE
Add vsp2.rules for Kingfisher

### DIFF
--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-graphics/wayland/weston/kingfisher/vsp2.rules
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-graphics/wayland/weston/kingfisher/vsp2.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="media", DEVPATH=="*/fe920000.vsp/media*", SYMLINK+="vsp2-renderer"


### PR DESCRIPTION
Existing vsp2.rules that identifies fe960000.vsp as a H/W for
VSP renderer is suitable for Salvator-X board, but on Kingfisher
it leads to blank screen. On Kingfisher we need to use another H/W
which is fe920000.vsp.

Place new file into a folder dedicated for Kingfisher.

Signed-off-by: Oleksandr Tyshchenko <oleksandr_tyshchenko@epam.com>