### PR TITLE
[WIP] Basic VirtIO support

### DIFF
--- a/inc/xen-version.inc
+++ b/inc/xen-version.inc
@@ -5,4 +5,20 @@
 ################################################################################
 require ../meta-xt-images-domx/recipes-extended/xen/xen-4.14-thud.inc
 
-SRC_URI = "git://github.com/xen-troops/xen.git;protocol=https;branch=xen-4.14rc-migration"
+SRC_URI = "git://github.com/xen-troops/xen.git;protocol=https;branch=xen-4.15rc-migration"
+
+# TODO: Strings below are subject for new xen-4.15-xxx.inc
+FILES_${PN}-xl-examples += " \
+    ${sysconfdir}/xen/xlexample.pvhlinux \
+"
+
+PACKAGES_append = " \
+    ${PN}-xen-access \
+    "
+FILES_${PN}-xen-access += " \
+    ${sbindir}/xen-access \
+"
+
+FILES_${PN}-misc_append = " \
+    ${sysconfdir}/bash_completion.d \
+"

--- a/recipes-dom0/dom0-image-thin-initramfs/dom0-image-thin-initramfs.bbappend
+++ b/recipes-dom0/dom0-image-thin-initramfs/dom0-image-thin-initramfs.bbappend
@@ -64,6 +64,11 @@ add_to_local_conf() {
     base_update_conf_value ${local_conf} PREFERRED_VERSION_xen "4.14.0+git\%"
 
     base_update_conf_value ${local_conf} XT_GUESTS_INSTALL "${XT_GUESTS_INSTALL}"
+
+    # we enable VirtIO feature only for H3 ES3 based machines
+    if echo "${MACHINEOVERRIDES}" | grep -qiv "r8a7795-es3"; then
+        base_set_conf_value ${local_conf} DISTRO_FEATURES_remove "virtio"
+    fi
 }
 
 python do_configure_append() {

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/doc/local.conf.dom0-image-minimal-initramfs
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/doc/local.conf.dom0-image-minimal-initramfs
@@ -226,7 +226,7 @@ DISTRO_FEATURES_append = " xen"
 DISTRO_FEATURES_append = " pvcamera"
 
 # Configuration for VirtIO feature
-#DISTRO_FEATURES_append = " virtio"
+DISTRO_FEATURES_append = " virtio"
 
 DEPLOY_DIR = "${TMPDIR}/deploy"
 IMAGE_ROOTFS = "${TMPDIR}/rootfs"

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/doc/local.conf.dom0-image-minimal-initramfs
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/doc/local.conf.dom0-image-minimal-initramfs
@@ -225,6 +225,9 @@ DISTRO_FEATURES_append = " xen"
 # Configuration for Para-virtual camera
 DISTRO_FEATURES_append = " pvcamera"
 
+# Configuration for VirtIO feature
+#DISTRO_FEATURES_append = " virtio"
+
 DEPLOY_DIR = "${TMPDIR}/deploy"
 IMAGE_ROOTFS = "${TMPDIR}/rootfs"
 XT_SHARED_ROOTFS_DIR = "${IMAGE_ROOTFS}/shared_rootfs"

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/doma.bb
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/doma.bb
@@ -56,4 +56,19 @@ do_install() {
         # Update GUEST_DEPENDENCIES by adding camerabe after sndbe
         sed -i 's/\<sndbe\>/& camerabe/' ${D}${sysconfdir}/init.d/guest_doma
     fi
+
+    if ${@bb.utils.contains('DISTRO_FEATURES', 'virtio', 'true', 'false', d)}; then
+        # Uncomment vdisk + virtio properties
+        sed -i 's/#vdisk =/vdisk =/' \
+        ${D}${base_prefix}${XT_DIR_ABS_ROOTFS_DOM_CFG}/doma.cfg
+        sed -i 's/#virtio =/virtio =/' \
+        ${D}${base_prefix}${XT_DIR_ABS_ROOTFS_DOM_CFG}/doma.cfg
+
+        # Update boot_devices by changing 51712 to 2000000
+        sed -i 's/androidboot.boot_devices=51712/androidboot.boot_devices=2000000.virtio/' \
+        ${D}${base_prefix}${XT_DIR_ABS_ROOTFS_DOM_CFG}/doma.cfg
+
+        # Update GUEST_DEPENDENCIES by adding virtio-disk after sndbe
+        sed -i 's/\<sndbe\>/& virtio-disk/' ${D}${sysconfdir}/init.d/guest_doma
+    fi
 }

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/domd.bb
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/domd.bb
@@ -60,4 +60,10 @@ do_install() {
 
     install -d ${D}${sysconfdir}/init.d
     install -m 0744 ${WORKDIR}/guest_domd ${D}${sysconfdir}/init.d/
+
+    if ${@bb.utils.contains('DISTRO_FEATURES', 'virtio', 'true', 'false', d)}; then
+        # Increase XT page pool
+        sed -i 's/xt_page_pool=67108864/xt_page_pool=603979776/' \
+        ${D}${base_prefix}${XT_DIR_ABS_ROOTFS_DOM_CFG}/domd.cfg
+    fi
 }

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/domu.bb
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/domu.bb
@@ -64,4 +64,21 @@ do_install() {
         # Update GUEST_DEPENDENCIES by adding camerabe after sndbe
         sed -i 's/\<sndbe\>/& camerabe/' ${D}${sysconfdir}/init.d/guest_domu
     fi
+
+    if ${@bb.utils.contains('DISTRO_FEATURES', 'virtio', 'true', 'false', d)}; then
+        # Comment disk and uncomment vdisk + virtio properties
+        sed -i 's/\bdisk =/#disk =/' \
+        ${D}${base_prefix}${XT_DIR_ABS_ROOTFS_DOM_CFG}/domu.cfg
+        sed -i 's/#vdisk =/vdisk =/' \
+        ${D}${base_prefix}${XT_DIR_ABS_ROOTFS_DOM_CFG}/domu.cfg
+        sed -i 's/#virtio =/virtio =/' \
+        ${D}${base_prefix}${XT_DIR_ABS_ROOTFS_DOM_CFG}/domu.cfg
+
+        # Update root by changing xvda1 to vda
+        sed -i 's/root=\/dev\/xvda1/root=\/dev\/vda/' \
+        ${D}${base_prefix}${XT_DIR_ABS_ROOTFS_DOM_CFG}/domu.cfg
+
+        # Update GUEST_DEPENDENCIES by adding virtio-disk after sndbe
+        sed -i 's/\<sndbe\>/& virtio-disk/' ${D}${sysconfdir}/init.d/guest_domu
+    fi
 }

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/doma-generic-h3-4x2g.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/doma-generic-h3-4x2g.cfg
@@ -33,7 +33,7 @@ dt_passthrough_nodes = [
 extra = "ip=dhcp androidboot.boot_devices=51712 androidboot.hardware=xenvm init=/init ro rootwait console=hvc0 cma=256M@1-2G androidboot.selinux=permissive pvrsrvkm.DriverMode=1 androidboot.android_dt_dir=/proc/device-tree/firmware#1/android/ xt_page_pool=2097152 xt_cma=4194304"
 
 # Initial memory allocation (MB)
-memory = 6000
+memory = 5120
 
 # Number of VCPUS
 vcpus = 4

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/doma-vdevices.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/doma-vdevices.cfg
@@ -6,6 +6,8 @@ vgsx = [ 'backend=DomD, osid=1' ]
 
 # Android uses disk with it's own partitions so no index after xvda
 disk = [ 'backend=DomD, phy:/var/run/android-disks/doma, xvda' ]
+#vdisk = [ 'backend=DomD, disks=rw:/var/run/android-disks/doma' ]
+#virtio = 1
 
 # We use predefined MAC addresses for domains:
 #  08:00:27:ff:cb:cd - domF

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domd-h3ulcb-4x2g-kf.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domd-h3ulcb-4x2g-kf.cfg
@@ -19,7 +19,7 @@ device_tree = "/xt/domd/domd.dtb"
 extra = "root=/dev/STORAGE_PART2 rw rootwait console=hvc0 pvrsrvkm.DriverMode=0 xt_page_pool=67108864 xt_cma=100663296"
 
 # Initial memory allocation (MB)
-memory = 1280
+memory = 2048
 
 # Number of VCPUS
 vcpus = 4

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domd-h3ulcb-4x2g.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domd-h3ulcb-4x2g.cfg
@@ -19,7 +19,7 @@ device_tree = "/xt/domd/domd.dtb"
 extra = "root=/dev/STORAGE_PART2 rw rootwait console=hvc0 pvrsrvkm.DriverMode=0 xt_page_pool=67108864 xt_cma=100663296"
 
 # Initial memory allocation (MB)
-memory = 1280
+memory = 2048
 
 # Number of VCPUS
 vcpus = 4

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domd-salvator-x-h3-4x2g.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domd-salvator-x-h3-4x2g.cfg
@@ -19,7 +19,7 @@ device_tree = "/xt/domd/domd.dtb"
 extra = "root=/dev/STORAGE_PART2 rw rootwait console=hvc0 pvrsrvkm.DriverMode=0 xt_page_pool=67108864 xt_cma=100663296"
 
 # Initial memory allocation (MB)
-memory = 1280
+memory = 2048
 
 # Number of VCPUS
 vcpus = 4

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domd-salvator-xs-h3-4x2g.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domd-salvator-xs-h3-4x2g.cfg
@@ -19,7 +19,7 @@ device_tree = "/xt/domd/domd.dtb"
 extra = "root=/dev/STORAGE_PART2 rw rootwait console=hvc0 pvrsrvkm.DriverMode=0 xt_page_pool=67108864 xt_cma=100663296"
 
 # Initial memory allocation (MB)
-memory = 1280
+memory = 2048
 
 # Number of VCPUS
 vcpus = 4

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domu-generic-h3-4x2g.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domu-generic-h3-4x2g.cfg
@@ -21,8 +21,8 @@ dtdev = [
 
 # Kernel command line options
 # You have to use line related to your boot device. Only one line can be used.
-# In case boot from network      - use line with 'root=/dev/nfs'   AND   comment out 'disk' in domu-vdevices.cfg.
-# In case boot from block device - use line with 'root=/dev/xvda1' AND uncomment     'disk' in domu-vdevices.cfg.
+# In case boot from network      - use line with 'root=/dev/nfs' AND comment out 'disk' (and 'vdisk' + 'virtio') in domu-vdevices.cfg.
+# In case boot from block device - use line with 'root=/dev/xvda1' (or 'root=/dev/vda') AND uncomment 'disk' (or 'vdisk' + 'virtio') in domu-vdevices.cfg.
 # -----
 # Uncomment this when using nfs as a boot device, and comment out 'disk'
 #extra = "root=/dev/nfs nfsroot=192.168.1.100:/srv/domu,vers=3 ip=dhcp rw rootwait console=hvc0 cma=256M@1-2G pvrsrvkm.DriverMode=1 xt_page_pool=2097152 xt_cma=4194304"

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domu-vdevices.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domu-vdevices.cfg
@@ -3,9 +3,11 @@
 # =====================================================================
 
 # See additional comment above line 'extra = ' in machine dependent config.
-# In case boot from network      -   comment out 'disk' AND use line with 'root=/dev/nfs' in machine dependent config.
-# In case boot from block device - uncomment     'disk' AND use line with 'root=/dev/xvda1' in machine dependent config.
+# In case boot from network - comment out 'disk' (and 'vdisk' + 'virtio') AND use line with 'root=/dev/nfs' in machine dependent config.
+# In case boot from block device - uncomment 'disk' (or 'vdisk' + 'virtio') AND use line with 'root=/dev/xvda1' (or 'root=/dev/vda') in machine dependent config.
 disk = [ 'backend=DomD, phy:/dev/STORAGE_PART3, xvda1' ]
+#vdisk = [ 'backend=DomD, disks=rw:/dev/STORAGE_PART3' ]
+#virtio = 1
 
 vgsx = [ 'backend=DomD, osid=1' ]
 

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/xen/files/0001-libxl-Add-DTB-compatible-list-to-config-file.patch
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/xen/files/0001-libxl-Add-DTB-compatible-list-to-config-file.patch
@@ -1,4 +1,4 @@
-From 8561720d294b4b19934b20cec1daf2a6e12913ea Mon Sep 17 00:00:00 2001
+From 8701a270e95cce8c29b645121edd1914b1b65aff Mon Sep 17 00:00:00 2001
 From: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>
 Date: Wed, 4 Apr 2018 20:15:50 +0300
 Subject: [PATCH 1/2] libxl: Add DTB compatible list to config file
@@ -12,16 +12,16 @@ by providing "dtb_compatible" list of strings separated by comas.
 Signed-off-by: Iurii Konovalenko <iurii.konovalenko@globallogic.com>
 Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>
 ---
- tools/libxl/libxl_arm.c     | 42 ++++++++++++++++++++++++++++++++++--------
- tools/libxl/libxl_types.idl |  1 +
- tools/xl/xl_parse.c         |  7 +++++++
+ tools/libs/light/libxl_arm.c     | 42 ++++++++++++++++++++++++++++++++--------
+ tools/libs/light/libxl_types.idl |  1 +
+ tools/xl/xl_parse.c              |  7 +++++++
  3 files changed, 42 insertions(+), 8 deletions(-)
 
-diff --git a/tools/libxl/libxl_arm.c b/tools/libxl/libxl_arm.c
-index e70acc5..4225cf6 100644
---- a/tools/libxl/libxl_arm.c
-+++ b/tools/libxl/libxl_arm.c
-@@ -278,20 +278,46 @@ static int fdt_property_regs(libxl__gc *gc, void *fdt,
+diff --git a/tools/libs/light/libxl_arm.c b/tools/libs/light/libxl_arm.c
+index eb9376b..13a8cae 100644
+--- a/tools/libs/light/libxl_arm.c
++++ b/tools/libs/light/libxl_arm.c
+@@ -319,20 +319,46 @@ static int fdt_property_regs(libxl__gc *gc, void *fdt,
  
  static int make_root_properties(libxl__gc *gc,
                                  const libxl_version_info *vers,
@@ -75,7 +75,7 @@ index e70acc5..4225cf6 100644
      if (res) return res;
  
      res = fdt_property_cell(fdt, "interrupt-parent", GUEST_PHANDLE_GIC);
-@@ -938,7 +964,7 @@ next_resize:
+@@ -1012,7 +1038,7 @@ next_resize:
  
          FDT( fdt_begin_node(fdt, "") );
  
@@ -84,10 +84,10 @@ index e70acc5..4225cf6 100644
          FDT( make_chosen_node(gc, fdt, !!dom->modules[0].blob, state, info) );
          FDT( make_cpus_node(gc, fdt, info->max_vcpus, ainfo) );
          FDT( make_psci_node(gc, fdt) );
-diff --git a/tools/libxl/libxl_types.idl b/tools/libxl/libxl_types.idl
-index 679dac6..2505220 100644
---- a/tools/libxl/libxl_types.idl
-+++ b/tools/libxl/libxl_types.idl
+diff --git a/tools/libs/light/libxl_types.idl b/tools/libs/light/libxl_types.idl
+index 7a2efd6..f99ca7f 100644
+--- a/tools/libs/light/libxl_types.idl
++++ b/tools/libs/light/libxl_types.idl
 @@ -550,6 +550,7 @@ libxl_domain_build_info = Struct("domain_build_info",[
      # Note that the partial device tree should avoid to use the phandle
      # 65000 which is reserved by the toolstack.
@@ -97,10 +97,10 @@ index 679dac6..2505220 100644
      ("bootloader",       string),
      ("bootloader_args",  libxl_string_list),
 diff --git a/tools/xl/xl_parse.c b/tools/xl/xl_parse.c
-index 1e6871a..863c6ee 100644
+index 680f9df..780b778 100644
 --- a/tools/xl/xl_parse.c
 +++ b/tools/xl/xl_parse.c
-@@ -2663,6 +2663,13 @@ skip_vfb:
+@@ -2779,6 +2779,13 @@ skip_vfb:
          }
      }
  

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/xen/files/0002-libxl-Add-DTB-passthrough-nodes-list.patch
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/xen/files/0002-libxl-Add-DTB-passthrough-nodes-list.patch
@@ -1,4 +1,4 @@
-From 11126b1e1d46ea629283eb55e077e94bf6ef6215 Mon Sep 17 00:00:00 2001
+From f0c6d5d6599f3429e459659804b83599b9151413 Mon Sep 17 00:00:00 2001
 From: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>
 Date: Wed, 4 Apr 2018 20:22:27 +0300
 Subject: [PATCH 2/2] libxl: Add DTB passthrough nodes list
@@ -14,16 +14,16 @@ comas.
 Signed-off-by: Iurii Konovalenko <iurii.konovalenko@globallogic.com>
 Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>
 ---
- tools/libxl/libxl_arm.c     | 20 ++++++++++++++++----
- tools/libxl/libxl_types.idl |  1 +
- tools/xl/xl_parse.c         |  7 +++++++
+ tools/libs/light/libxl_arm.c     | 20 ++++++++++++++++----
+ tools/libs/light/libxl_types.idl |  1 +
+ tools/xl/xl_parse.c              |  7 +++++++
  3 files changed, 24 insertions(+), 4 deletions(-)
 
-diff --git a/tools/libxl/libxl_arm.c b/tools/libxl/libxl_arm.c
-index 4225cf6..1e9f04c 100644
---- a/tools/libxl/libxl_arm.c
-+++ b/tools/libxl/libxl_arm.c
-@@ -843,9 +843,10 @@ static int copy_node_by_path(libxl__gc *gc, const char *path,
+diff --git a/tools/libs/light/libxl_arm.c b/tools/libs/light/libxl_arm.c
+index 13a8cae..a8a215c 100644
+--- a/tools/libs/light/libxl_arm.c
++++ b/tools/libs/light/libxl_arm.c
+@@ -917,9 +917,10 @@ static int copy_node_by_path(libxl__gc *gc, const char *path,
   *  - /passthrough node
   *  - /aliases node
   */
@@ -36,7 +36,7 @@ index 4225cf6..1e9f04c 100644
  
      r = copy_node_by_path(gc, "/passthrough", fdt, pfdt);
      if (r < 0) {
-@@ -859,6 +860,16 @@ static int copy_partial_fdt(libxl__gc *gc, void *fdt, void *pfdt)
+@@ -933,6 +934,16 @@ static int copy_partial_fdt(libxl__gc *gc, void *fdt, void *pfdt)
          return r;
      }
  
@@ -53,7 +53,7 @@ index 4225cf6..1e9f04c 100644
      return 0;
  }
  
-@@ -871,7 +882,8 @@ static int check_partial_fdt(libxl__gc *gc, void *fdt, size_t size)
+@@ -945,7 +956,8 @@ static int check_partial_fdt(libxl__gc *gc, void *fdt, size_t size)
      return ERROR_FAIL;
  }
  
@@ -63,8 +63,8 @@ index 4225cf6..1e9f04c 100644
  {
      /*
       * We should never be here when the partial device tree is not
-@@ -997,7 +1009,7 @@ next_resize:
-             FDT( make_optee_node(gc, fdt) );
+@@ -1085,7 +1097,7 @@ next_resize:
+         }
  
          if (pfdt)
 -            FDT( copy_partial_fdt(gc, fdt, pfdt) );
@@ -72,10 +72,10 @@ index 4225cf6..1e9f04c 100644
  
          FDT( fdt_end_node(fdt) );
  
-diff --git a/tools/libxl/libxl_types.idl b/tools/libxl/libxl_types.idl
-index 2505220..90425f1 100644
---- a/tools/libxl/libxl_types.idl
-+++ b/tools/libxl/libxl_types.idl
+diff --git a/tools/libs/light/libxl_types.idl b/tools/libs/light/libxl_types.idl
+index f99ca7f..b6a9b2b 100644
+--- a/tools/libs/light/libxl_types.idl
++++ b/tools/libs/light/libxl_types.idl
 @@ -551,6 +551,7 @@ libxl_domain_build_info = Struct("domain_build_info",[
      # 65000 which is reserved by the toolstack.
      ("device_tree",      string),
@@ -85,10 +85,10 @@ index 2505220..90425f1 100644
      ("bootloader",       string),
      ("bootloader_args",  libxl_string_list),
 diff --git a/tools/xl/xl_parse.c b/tools/xl/xl_parse.c
-index 863c6ee..6c00d16 100644
+index 780b778..df675ac 100644
 --- a/tools/xl/xl_parse.c
 +++ b/tools/xl/xl_parse.c
-@@ -2670,6 +2670,13 @@ skip_vfb:
+@@ -2786,6 +2786,13 @@ skip_vfb:
              exit(-ERROR_FAIL);
      }
  

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-kernel/linux/linux-generic-armv8.bbappend
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-kernel/linux/linux-generic-armv8.bbappend
@@ -8,6 +8,11 @@ SRC_URI = " \
     git://github.com/xen-troops/linux.git;branch=${BRANCH} \
     file://defconfig \
   "
+
+SRC_URI_append = " \
+    file://0001-xen-privcmd-add-IOCTL_PRIVCMD_MMAP_RESOURCE.patch \
+"
+
 do_deploy_append () {
     find ${D}/boot -iname "vmlinux*" -exec tar -cJvf ${STAGING_KERNEL_BUILDDIR}/vmlinux.tar.xz {} \;
 }

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-kernel/linux/linux-generic-armv8/0001-xen-privcmd-add-IOCTL_PRIVCMD_MMAP_RESOURCE.patch
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-kernel/linux/linux-generic-armv8/0001-xen-privcmd-add-IOCTL_PRIVCMD_MMAP_RESOURCE.patch
@@ -1,0 +1,503 @@
+From d3e0d8b5d83f23cd639695827d64ba299104c196 Mon Sep 17 00:00:00 2001
+From: Paul Durrant <paul.durrant@citrix.com>
+Date: Wed, 9 May 2018 14:16:12 +0100
+Subject: [PATCH] xen/privcmd: add IOCTL_PRIVCMD_MMAP_RESOURCE
+
+[ Upstream commit 3ad0876554ca ]
+
+My recent Xen patch series introduces a new HYPERVISOR_memory_op to
+support direct priv-mapping of certain guest resources (such as ioreq
+pages, used by emulators) by a tools domain, rather than having to access
+such resources via the guest P2M.
+
+This patch adds the necessary infrastructure to the privcmd driver and
+Xen MMU code to support direct resource mapping.
+
+NOTE: The adjustment in the MMU code is partially cosmetic. Xen will now
+      allow a PV tools domain to map guest pages either by GFN or MFN, thus
+      the term 'mfn' has been swapped for 'pfn' in the lower layers of the
+      remap code.
+
+Signed-off-by: Paul Durrant <paul.durrant@citrix.com>
+Reviewed-by: Boris Ostrovsky <boris.ostrovsky@oracle.com>
+Signed-off-by: Juergen Gross <jgross@suse.com>
+---
+ arch/arm/xen/enlighten.c       |  11 ++++
+ arch/x86/xen/mmu.c             |  60 +++++++++++++------
+ drivers/xen/privcmd.c          | 133 +++++++++++++++++++++++++++++++++++++++++
+ include/uapi/xen/privcmd.h     |  11 ++++
+ include/xen/interface/memory.h |  66 ++++++++++++++++++++
+ include/xen/interface/xen.h    |   7 ++-
+ include/xen/xen-ops.h          |  24 +++++++-
+ 7 files changed, 291 insertions(+), 21 deletions(-)
+
+diff --git a/arch/arm/xen/enlighten.c b/arch/arm/xen/enlighten.c
+index 179bfb3..463782d 100644
+--- a/arch/arm/xen/enlighten.c
++++ b/arch/arm/xen/enlighten.c
+@@ -93,6 +93,17 @@ int xen_unmap_domain_gfn_range(struct vm_area_struct *vma,
+ }
+ EXPORT_SYMBOL_GPL(xen_unmap_domain_gfn_range);
+ 
++/* Not used by XENFEAT_auto_translated guests. */
++int xen_remap_domain_mfn_array(struct vm_area_struct *vma,
++			       unsigned long addr,
++			       xen_pfn_t *mfn, int nr,
++			       int *err_ptr, pgprot_t prot,
++			       unsigned int domid, struct page **pages)
++{
++	return -ENOSYS;
++}
++EXPORT_SYMBOL_GPL(xen_remap_domain_mfn_array);
++
+ static void xen_read_wallclock(struct timespec64 *ts)
+ {
+ 	u32 version;
+diff --git a/arch/x86/xen/mmu.c b/arch/x86/xen/mmu.c
+index de02633..8d09ac4 100644
+--- a/arch/x86/xen/mmu.c
++++ b/arch/x86/xen/mmu.c
+@@ -63,37 +63,44 @@ static noinline void xen_flush_tlb_all(void)
+ #define REMAP_BATCH_SIZE 16
+ 
+ struct remap_data {
+-	xen_pfn_t *mfn;
++	xen_pfn_t *pfn;
+ 	bool contiguous;
++	bool no_translate;
+ 	pgprot_t prot;
+ 	struct mmu_update *mmu_update;
+ };
+ 
+-static int remap_area_mfn_pte_fn(pte_t *ptep, pgtable_t token,
++static int remap_area_pfn_pte_fn(pte_t *ptep, pgtable_t token,
+ 				 unsigned long addr, void *data)
+ {
+ 	struct remap_data *rmd = data;
+-	pte_t pte = pte_mkspecial(mfn_pte(*rmd->mfn, rmd->prot));
++	pte_t pte = pte_mkspecial(mfn_pte(*rmd->pfn, rmd->prot));
+ 
+-	/* If we have a contiguous range, just update the mfn itself,
+-	   else update pointer to be "next mfn". */
++	/*
++	 * If we have a contiguous range, just update the pfn itself,
++	 * else update pointer to be "next pfn".
++	 */
+ 	if (rmd->contiguous)
+-		(*rmd->mfn)++;
++		(*rmd->pfn)++;
+ 	else
+-		rmd->mfn++;
++		rmd->pfn++;
+ 
+-	rmd->mmu_update->ptr = virt_to_machine(ptep).maddr | MMU_NORMAL_PT_UPDATE;
++	rmd->mmu_update->ptr = virt_to_machine(ptep).maddr;
++	rmd->mmu_update->ptr |= rmd->no_translate ?
++		MMU_PT_UPDATE_NO_TRANSLATE :
++		MMU_NORMAL_PT_UPDATE;
+ 	rmd->mmu_update->val = pte_val_ma(pte);
+ 	rmd->mmu_update++;
+ 
+ 	return 0;
+ }
+ 
+-static int do_remap_gfn(struct vm_area_struct *vma,
++static int do_remap_pfn(struct vm_area_struct *vma,
+ 			unsigned long addr,
+-			xen_pfn_t *gfn, int nr,
++			xen_pfn_t *pfn, int nr,
+ 			int *err_ptr, pgprot_t prot,
+-			unsigned domid,
++			unsigned int domid,
++			bool no_translate,
+ 			struct page **pages)
+ {
+ 	int err = 0;
+@@ -104,11 +111,14 @@ static int do_remap_gfn(struct vm_area_struct *vma,
+ 
+ 	BUG_ON(!((vma->vm_flags & (VM_PFNMAP | VM_IO)) == (VM_PFNMAP | VM_IO)));
+ 
+-	rmd.mfn = gfn;
++	rmd.pfn = pfn;
+ 	rmd.prot = prot;
+-	/* We use the err_ptr to indicate if there we are doing a contiguous
+-	 * mapping or a discontigious mapping. */
++	/*
++	 * We use the err_ptr to indicate if there we are doing a contiguous
++	 * mapping or a discontigious mapping.
++	 */
+ 	rmd.contiguous = !err_ptr;
++	rmd.no_translate = no_translate;
+ 
+ 	while (nr) {
+ 		int index = 0;
+@@ -119,7 +129,7 @@ static int do_remap_gfn(struct vm_area_struct *vma,
+ 
+ 		rmd.mmu_update = mmu_update;
+ 		err = apply_to_page_range(vma->vm_mm, addr, range,
+-					  remap_area_mfn_pte_fn, &rmd);
++					  remap_area_pfn_pte_fn, &rmd);
+ 		if (err)
+ 			goto out;
+ 
+@@ -170,7 +180,8 @@ int xen_remap_domain_gfn_range(struct vm_area_struct *vma,
+ 			       pgprot_t prot, unsigned domid,
+ 			       struct page **pages)
+ {
+-	return do_remap_gfn(vma, addr, &gfn, nr, NULL, prot, domid, pages);
++	return do_remap_pfn(vma, addr, &gfn, nr, NULL, prot, domid, false,
++			    pages);
+ }
+ EXPORT_SYMBOL_GPL(xen_remap_domain_gfn_range);
+ 
+@@ -185,10 +196,25 @@ int xen_remap_domain_gfn_array(struct vm_area_struct *vma,
+ 	 * cause of "wrong memory was mapped in".
+ 	 */
+ 	BUG_ON(err_ptr == NULL);
+-	return do_remap_gfn(vma, addr, gfn, nr, err_ptr, prot, domid, pages);
++	return do_remap_pfn(vma, addr, gfn, nr, err_ptr, prot, domid,
++			    false, pages);
+ }
+ EXPORT_SYMBOL_GPL(xen_remap_domain_gfn_array);
+ 
++int xen_remap_domain_mfn_array(struct vm_area_struct *vma,
++			       unsigned long addr,
++			       xen_pfn_t *mfn, int nr,
++			       int *err_ptr, pgprot_t prot,
++			       unsigned int domid, struct page **pages)
++{
++	if (xen_feature(XENFEAT_auto_translated_physmap))
++		return -EOPNOTSUPP;
++
++	return do_remap_pfn(vma, addr, mfn, nr, err_ptr, prot, domid,
++			    true, pages);
++}
++EXPORT_SYMBOL_GPL(xen_remap_domain_mfn_array);
++
+ /* Returns: 0 success */
+ int xen_unmap_domain_gfn_range(struct vm_area_struct *vma,
+ 			       int numpgs, struct page **pages)
+diff --git a/drivers/xen/privcmd.c b/drivers/xen/privcmd.c
+index feca75b..39562be 100644
+--- a/drivers/xen/privcmd.c
++++ b/drivers/xen/privcmd.c
+@@ -33,6 +33,7 @@
+ #include <xen/xen.h>
+ #include <xen/privcmd.h>
+ #include <xen/interface/xen.h>
++#include <xen/interface/memory.h>
+ #include <xen/interface/hvm/dm_op.h>
+ #include <xen/features.h>
+ #include <xen/page.h>
+@@ -725,6 +726,134 @@ static long privcmd_ioctl_restrict(struct file *file, void __user *udata)
+ 	return 0;
+ }
+ 
++struct remap_pfn {
++	struct mm_struct *mm;
++	struct page **pages;
++	pgprot_t prot;
++	unsigned long i;
++};
++
++static int remap_pfn_fn(pte_t *ptep, pgtable_t token, unsigned long addr,
++			void *data)
++{
++	struct remap_pfn *r = data;
++	struct page *page = r->pages[r->i];
++	pte_t pte = pte_mkspecial(pfn_pte(page_to_pfn(page), r->prot));
++
++	set_pte_at(r->mm, addr, ptep, pte);
++	r->i++;
++
++	return 0;
++}
++
++static long privcmd_ioctl_mmap_resource(struct file *file, void __user *udata)
++{
++	struct privcmd_data *data = file->private_data;
++	struct mm_struct *mm = current->mm;
++	struct vm_area_struct *vma;
++	struct privcmd_mmap_resource kdata;
++	xen_pfn_t *pfns = NULL;
++	struct xen_mem_acquire_resource xdata;
++	int rc;
++
++	if (copy_from_user(&kdata, udata, sizeof(kdata)))
++		return -EFAULT;
++
++	/* If restriction is in place, check the domid matches */
++	if (data->domid != DOMID_INVALID && data->domid != kdata.dom)
++		return -EPERM;
++
++	down_write(&mm->mmap_sem);
++
++	vma = find_vma(mm, kdata.addr);
++	if (!vma || vma->vm_ops != &privcmd_vm_ops) {
++		rc = -EINVAL;
++		goto out;
++	}
++
++	pfns = kcalloc(kdata.num, sizeof(*pfns), GFP_KERNEL);
++	if (!pfns) {
++		rc = -ENOMEM;
++		goto out;
++	}
++
++	if (xen_feature(XENFEAT_auto_translated_physmap)) {
++		unsigned int nr = DIV_ROUND_UP(kdata.num, XEN_PFN_PER_PAGE);
++		struct page **pages;
++		unsigned int i;
++
++		rc = alloc_empty_pages(vma, nr);
++		if (rc < 0)
++			goto out;
++
++		pages = vma->vm_private_data;
++		for (i = 0; i < kdata.num; i++) {
++			xen_pfn_t pfn =
++				page_to_xen_pfn(pages[i / XEN_PFN_PER_PAGE]);
++
++			pfns[i] = pfn + (i % XEN_PFN_PER_PAGE);
++		}
++	} else
++		vma->vm_private_data = PRIV_VMA_LOCKED;
++
++	memset(&xdata, 0, sizeof(xdata));
++	xdata.domid = kdata.dom;
++	xdata.type = kdata.type;
++	xdata.id = kdata.id;
++	xdata.frame = kdata.idx;
++	xdata.nr_frames = kdata.num;
++	set_xen_guest_handle(xdata.frame_list, pfns);
++
++	xen_preemptible_hcall_begin();
++	rc = HYPERVISOR_memory_op(XENMEM_acquire_resource, &xdata);
++	xen_preemptible_hcall_end();
++
++	if (rc)
++		goto out;
++
++	if (xen_feature(XENFEAT_auto_translated_physmap)) {
++		struct remap_pfn r = {
++			.mm = vma->vm_mm,
++			.pages = vma->vm_private_data,
++			.prot = vma->vm_page_prot,
++		};
++
++		rc = apply_to_page_range(r.mm, kdata.addr,
++					 kdata.num << PAGE_SHIFT,
++					 remap_pfn_fn, &r);
++	} else {
++		unsigned int domid =
++			(xdata.flags & XENMEM_rsrc_acq_caller_owned) ?
++			DOMID_SELF : kdata.dom;
++		int num;
++
++		num = xen_remap_domain_mfn_array(vma,
++						 kdata.addr & PAGE_MASK,
++						 pfns, kdata.num, (int *)pfns,
++						 vma->vm_page_prot,
++						 domid,
++						 vma->vm_private_data);
++		if (num < 0)
++			rc = num;
++		else if (num != kdata.num) {
++			unsigned int i;
++
++			for (i = 0; i < num; i++) {
++				rc = pfns[i];
++				if (rc < 0)
++					break;
++			}
++		} else
++			rc = 0;
++	}
++
++out:
++	up_write(&mm->mmap_sem);
++	kfree(pfns);
++
++	return rc;
++}
++
+ static long privcmd_ioctl(struct file *file,
+ 			  unsigned int cmd, unsigned long data)
+ {
+@@ -756,6 +885,10 @@ static long privcmd_ioctl(struct file *file,
+ 		ret = privcmd_ioctl_restrict(file, udata);
+ 		break;
+ 
++	case IOCTL_PRIVCMD_MMAP_RESOURCE:
++		ret = privcmd_ioctl_mmap_resource(file, udata);
++		break;
++
+ 	default:
+ 		break;
+ 	}
+diff --git a/include/uapi/xen/privcmd.h b/include/uapi/xen/privcmd.h
+index 39d3e7b..d202955 100644
+--- a/include/uapi/xen/privcmd.h
++++ b/include/uapi/xen/privcmd.h
+@@ -89,6 +89,15 @@ struct privcmd_dm_op {
+ 	const struct privcmd_dm_op_buf __user *ubufs;
+ };
+ 
++struct privcmd_mmap_resource {
++	domid_t dom;
++	__u32 type;
++	__u32 id;
++	__u32 idx;
++	__u64 num;
++	__u64 addr;
++};
++
+ /*
+  * @cmd: IOCTL_PRIVCMD_HYPERCALL
+  * @arg: &privcmd_hypercall_t
+@@ -114,5 +123,7 @@ struct privcmd_dm_op {
+ 	_IOC(_IOC_NONE, 'P', 5, sizeof(struct privcmd_dm_op))
+ #define IOCTL_PRIVCMD_RESTRICT					\
+ 	_IOC(_IOC_NONE, 'P', 6, sizeof(domid_t))
++#define IOCTL_PRIVCMD_MMAP_RESOURCE				\
++	_IOC(_IOC_NONE, 'P', 7, sizeof(struct privcmd_mmap_resource))
+ 
+ #endif /* __LINUX_PUBLIC_PRIVCMD_H__ */
+diff --git a/include/xen/interface/memory.h b/include/xen/interface/memory.h
+index 583dd93..4c5751c 100644
+--- a/include/xen/interface/memory.h
++++ b/include/xen/interface/memory.h
+@@ -265,4 +265,70 @@ struct xen_remove_from_physmap {
+ };
+ DEFINE_GUEST_HANDLE_STRUCT(xen_remove_from_physmap);
+ 
++/*
++ * Get the pages for a particular guest resource, so that they can be
++ * mapped directly by a tools domain.
++ */
++#define XENMEM_acquire_resource 28
++struct xen_mem_acquire_resource {
++    /* IN - The domain whose resource is to be mapped */
++    domid_t domid;
++    /* IN - the type of resource */
++    uint16_t type;
++
++#define XENMEM_resource_ioreq_server 0
++#define XENMEM_resource_grant_table 1
++
++    /*
++     * IN - a type-specific resource identifier, which must be zero
++     *      unless stated otherwise.
++     *
++     * type == XENMEM_resource_ioreq_server -> id == ioreq server id
++     * type == XENMEM_resource_grant_table -> id defined below
++     */
++    uint32_t id;
++
++#define XENMEM_resource_grant_table_id_shared 0
++#define XENMEM_resource_grant_table_id_status 1
++
++    /* IN/OUT - As an IN parameter number of frames of the resource
++     *          to be mapped. However, if the specified value is 0 and
++     *          frame_list is NULL then this field will be set to the
++     *          maximum value supported by the implementation on return.
++     */
++    uint32_t nr_frames;
++    /*
++     * OUT - Must be zero on entry. On return this may contain a bitwise
++     *       OR of the following values.
++     */
++    uint32_t flags;
++
++    /* The resource pages have been assigned to the calling domain */
++#define _XENMEM_rsrc_acq_caller_owned 0
++#define XENMEM_rsrc_acq_caller_owned (1u << _XENMEM_rsrc_acq_caller_owned)
++
++    /*
++     * IN - the index of the initial frame to be mapped. This parameter
++     *      is ignored if nr_frames is 0.
++     */
++    uint64_t frame;
++
++#define XENMEM_resource_ioreq_server_frame_bufioreq 0
++#define XENMEM_resource_ioreq_server_frame_ioreq(n) (1 + (n))
++
++    /*
++     * IN/OUT - If the tools domain is PV then, upon return, frame_list
++     *          will be populated with the MFNs of the resource.
++     *          If the tools domain is HVM then it is expected that, on
++     *          entry, frame_list will be populated with a list of GFNs
++     *          that will be mapped to the MFNs of the resource.
++     *          If -EIO is returned then the frame_list has only been
++     *          partially mapped and it is up to the caller to unmap all
++     *          the GFNs.
++     *          This parameter may be NULL if nr_frames is 0.
++     */
++    GUEST_HANDLE(xen_pfn_t) frame_list;
++};
++DEFINE_GUEST_HANDLE_STRUCT(xen_mem_acquire_resource);
++
+ #endif /* __XEN_PUBLIC_MEMORY_H__ */
+diff --git a/include/xen/interface/xen.h b/include/xen/interface/xen.h
+index 4f4830e..8bfb242 100644
+--- a/include/xen/interface/xen.h
++++ b/include/xen/interface/xen.h
+@@ -265,9 +265,10 @@
+  *
+  * PAT (bit 7 on) --> PWT (bit 3 on) and clear bit 7.
+  */
+-#define MMU_NORMAL_PT_UPDATE      0 /* checked '*ptr = val'. ptr is MA.       */
+-#define MMU_MACHPHYS_UPDATE       1 /* ptr = MA of frame to modify entry for  */
+-#define MMU_PT_UPDATE_PRESERVE_AD 2 /* atomically: *ptr = val | (*ptr&(A|D)) */
++#define MMU_NORMAL_PT_UPDATE       0 /* checked '*ptr = val'. ptr is MA.      */
++#define MMU_MACHPHYS_UPDATE        1 /* ptr = MA of frame to modify entry for */
++#define MMU_PT_UPDATE_PRESERVE_AD  2 /* atomically: *ptr = val | (*ptr&(A|D)) */
++#define MMU_PT_UPDATE_NO_TRANSLATE 3 /* checked '*ptr = val'. ptr is MA.      */
+ 
+ /*
+  * MMU EXTENDED OPERATIONS
+diff --git a/include/xen/xen-ops.h b/include/xen/xen-ops.h
+index a95e65e..95d4ca6 100644
+--- a/include/xen/xen-ops.h
++++ b/include/xen/xen-ops.h
+@@ -62,7 +62,7 @@ static inline void xen_destroy_contiguous_region(phys_addr_t pstart,
+ struct vm_area_struct;
+ 
+ /*
+- * xen_remap_domain_gfn_array() - map an array of foreign frames
++ * xen_remap_domain_gfn_array() - map an array of foreign frames by gfn
+  * @vma:     VMA to map the pages into
+  * @addr:    Address at which to map the pages
+  * @gfn:     Array of GFNs to map
+@@ -85,6 +85,28 @@ int xen_remap_domain_gfn_array(struct vm_area_struct *vma,
+ 			       unsigned domid,
+ 			       struct page **pages);
+ 
++/*
++ * xen_remap_domain_mfn_array() - map an array of foreign frames by mfn
++ * @vma:     VMA to map the pages into
++ * @addr:    Address at which to map the pages
++ * @mfn:     Array of MFNs to map
++ * @nr:      Number entries in the MFN array
++ * @err_ptr: Returns per-MFN error status.
++ * @prot:    page protection mask
++ * @domid:   Domain owning the pages
++ * @pages:   Array of pages if this domain has an auto-translated physmap
++ *
++ * @mfn and @err_ptr may point to the same buffer, the MFNs will be
++ * overwritten by the error codes after they are mapped.
++ *
++ * Returns the number of successfully mapped frames, or a -ve error
++ * code.
++ */
++int xen_remap_domain_mfn_array(struct vm_area_struct *vma,
++			       unsigned long addr, xen_pfn_t *mfn, int nr,
++			       int *err_ptr, pgprot_t prot,
++			       unsigned int domid, struct page **pages);
++
+ /* xen_remap_domain_gfn_range() - map a range of foreign frames
+  * @vma:     VMA to map the pages into
+  * @addr:    Address at which to map the pages
+-- 
+2.7.4
+

--- a/recipes-domd/domd-image-weston/domd-image-weston.bbappend
+++ b/recipes-domd/domd-image-weston/domd-image-weston.bbappend
@@ -175,6 +175,11 @@ configure_versions_rcar() {
         base_set_conf_value ${local_conf} DISTRO_FEATURES_remove "v4l2-renderer"
     fi
 
+    # we enable VirtIO feature only for H3 ES3 based machines
+    if echo "${MACHINEOVERRIDES}" | grep -qiv "r8a7795-es3"; then
+        base_set_conf_value ${local_conf} DISTRO_FEATURES_remove "virtio"
+    fi
+
     base_update_conf_value ${local_conf} XT_RCAR_PROPRIETARY_MULTIMEDIA_DIR "${XT_RCAR_PROPRIETARY_MULTIMEDIA_DIR}"
 }
 

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/doc/local.conf.rcar-domd-image-weston
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/doc/local.conf.rcar-domd-image-weston
@@ -410,7 +410,7 @@ DISTRO_FEATURES_append = " virtualization"
 DISTRO_FEATURES_append = " pvcamera"
 
 # Configuration for VirtIO feature
-#DISTRO_FEATURES_append = " virtio"
+DISTRO_FEATURES_append = " virtio"
 
 DISTRO_FEATURES_remove = " x11 gtk gobject-introspection-data nfc irda zeroconf 3g"
 

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/doc/local.conf.rcar-domd-image-weston
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/doc/local.conf.rcar-domd-image-weston
@@ -409,6 +409,9 @@ DISTRO_FEATURES_append = " virtualization"
 # Configuration for Para-virtual camera
 DISTRO_FEATURES_append = " pvcamera"
 
+# Configuration for VirtIO feature
+#DISTRO_FEATURES_append = " virtio"
+
 DISTRO_FEATURES_remove = " x11 gtk gobject-introspection-data nfc irda zeroconf 3g"
 
 # Remove multimedia options if XT_RCAR_PROPRIETARY_MULTIMEDIA_DIR is not defined

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/doc/local.conf.rcar-domd-image-weston
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/doc/local.conf.rcar-domd-image-weston
@@ -423,3 +423,6 @@ ASSUME_PROVIDED += "sync-native"
 HOSTTOOLS += "sync"
 ASSUME_PROVIDED += "bison-native"
 HOSTTOOLS += "bison"
+
+# Add development tools (gcc, make, pkgconfig etc.)
+EXTRA_IMAGE_FEATURES += "tools-sdk"

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-core/packagegroups/packagegroup-xt-core-pv.bb
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-core/packagegroups/packagegroup-xt-core-pv.bb
@@ -8,6 +8,6 @@ RDEPENDS_packagegroup-xt-core-pv = "\
     libxenbe \
     displbe \
     sndbe \
-    virtio-disk \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'virtio', 'virtio-disk', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'pvcamera', 'camerabe', '', d)} \
 "

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-core/packagegroups/packagegroup-xt-core-pv.bb
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-core/packagegroups/packagegroup-xt-core-pv.bb
@@ -8,5 +8,6 @@ RDEPENDS_packagegroup-xt-core-pv = "\
     libxenbe \
     displbe \
     sndbe \
+    virtio-disk \
     ${@bb.utils.contains('DISTRO_FEATURES', 'pvcamera', 'camerabe', '', d)} \
 "

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-extended/virtio-disk/files/virtio-disk.service
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-extended/virtio-disk/files/virtio-disk.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=virtio-disk backend
+Requires=proc-xen.mount
+After=proc-xen.mount
+
+[Service]
+Type=simple
+Environment="XDG_RUNTIME_DIR=/run/user/0"
+ExecStartPre=
+ExecStart=/usr/bin/virtio-disk
+ExecStartPost=/usr/bin/xenstore-write drivers/virtio-disk/status ready
+ExecStop=/usr/bin/xenstore-write drivers/virtio-disk/status dead
+ExecStopPost=/usr/bin/xenstore-write drivers/virtio-disk/status dead
+Restart=always
+RestartSec=4
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-extended/virtio-disk/virtio-disk.bb
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-extended/virtio-disk/virtio-disk.bb
@@ -1,0 +1,34 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+require inc/xt_shared_env.inc
+
+DESCRIPTION = "virtio-disk"
+SECTION = "extras"
+LICENSE = "GPLv2"
+PR = "r0"
+
+LIC_FILES_CHKSUM = "file://LICENSE;md5=b234ee4d69f5fce4486a80fdaf4a4263"
+
+S = "${WORKDIR}/git"
+
+DEPENDS = "xen"
+
+SRCREV = "${AUTOREV}"
+
+SRC_URI_append = " \
+    git://github.com/xen-troops/virtio-disk.git;protocol=https;branch=ioreq_ml2 \
+    file://virtio-disk.service \
+"
+
+inherit systemd pkgconfig autotools-brokensep
+
+SYSTEMD_SERVICE_${PN} = "virtio-disk.service"
+
+do_install_append() {
+    install -d ${D}${systemd_system_unitdir}
+    install -m 0644 ${WORKDIR}/virtio-disk.service ${D}${systemd_system_unitdir}
+}
+
+FILES_${PN} += " \
+    ${systemd_system_unitdir}/virtio-disk.service \
+"

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-extended/xen/xen_git.bbappend
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-extended/xen/xen_git.bbappend
@@ -22,7 +22,7 @@ SRC_URI_append_r8a7796 = " \
 # Generic
 ################################################################################
 
-FLASK_POLICY_FILE = "xenpolicy-${XEN_REL}*"
+FLASK_POLICY_FILE = "xenpolicy-4.15-unstable"
 FILES_${PN}-flask = " \
     /boot/${FLASK_POLICY_FILE} \
 "

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas/0001-xen-privcmd-add-IOCTL_PRIVCMD_MMAP_RESOURCE.patch
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas/0001-xen-privcmd-add-IOCTL_PRIVCMD_MMAP_RESOURCE.patch
@@ -1,0 +1,503 @@
+From d3e0d8b5d83f23cd639695827d64ba299104c196 Mon Sep 17 00:00:00 2001
+From: Paul Durrant <paul.durrant@citrix.com>
+Date: Wed, 9 May 2018 14:16:12 +0100
+Subject: [PATCH] xen/privcmd: add IOCTL_PRIVCMD_MMAP_RESOURCE
+
+[ Upstream commit 3ad0876554ca ]
+
+My recent Xen patch series introduces a new HYPERVISOR_memory_op to
+support direct priv-mapping of certain guest resources (such as ioreq
+pages, used by emulators) by a tools domain, rather than having to access
+such resources via the guest P2M.
+
+This patch adds the necessary infrastructure to the privcmd driver and
+Xen MMU code to support direct resource mapping.
+
+NOTE: The adjustment in the MMU code is partially cosmetic. Xen will now
+      allow a PV tools domain to map guest pages either by GFN or MFN, thus
+      the term 'mfn' has been swapped for 'pfn' in the lower layers of the
+      remap code.
+
+Signed-off-by: Paul Durrant <paul.durrant@citrix.com>
+Reviewed-by: Boris Ostrovsky <boris.ostrovsky@oracle.com>
+Signed-off-by: Juergen Gross <jgross@suse.com>
+---
+ arch/arm/xen/enlighten.c       |  11 ++++
+ arch/x86/xen/mmu.c             |  60 +++++++++++++------
+ drivers/xen/privcmd.c          | 133 +++++++++++++++++++++++++++++++++++++++++
+ include/uapi/xen/privcmd.h     |  11 ++++
+ include/xen/interface/memory.h |  66 ++++++++++++++++++++
+ include/xen/interface/xen.h    |   7 ++-
+ include/xen/xen-ops.h          |  24 +++++++-
+ 7 files changed, 291 insertions(+), 21 deletions(-)
+
+diff --git a/arch/arm/xen/enlighten.c b/arch/arm/xen/enlighten.c
+index 179bfb3..463782d 100644
+--- a/arch/arm/xen/enlighten.c
++++ b/arch/arm/xen/enlighten.c
+@@ -93,6 +93,17 @@ int xen_unmap_domain_gfn_range(struct vm_area_struct *vma,
+ }
+ EXPORT_SYMBOL_GPL(xen_unmap_domain_gfn_range);
+ 
++/* Not used by XENFEAT_auto_translated guests. */
++int xen_remap_domain_mfn_array(struct vm_area_struct *vma,
++			       unsigned long addr,
++			       xen_pfn_t *mfn, int nr,
++			       int *err_ptr, pgprot_t prot,
++			       unsigned int domid, struct page **pages)
++{
++	return -ENOSYS;
++}
++EXPORT_SYMBOL_GPL(xen_remap_domain_mfn_array);
++
+ static void xen_read_wallclock(struct timespec64 *ts)
+ {
+ 	u32 version;
+diff --git a/arch/x86/xen/mmu.c b/arch/x86/xen/mmu.c
+index de02633..8d09ac4 100644
+--- a/arch/x86/xen/mmu.c
++++ b/arch/x86/xen/mmu.c
+@@ -63,37 +63,44 @@ static noinline void xen_flush_tlb_all(void)
+ #define REMAP_BATCH_SIZE 16
+ 
+ struct remap_data {
+-	xen_pfn_t *mfn;
++	xen_pfn_t *pfn;
+ 	bool contiguous;
++	bool no_translate;
+ 	pgprot_t prot;
+ 	struct mmu_update *mmu_update;
+ };
+ 
+-static int remap_area_mfn_pte_fn(pte_t *ptep, pgtable_t token,
++static int remap_area_pfn_pte_fn(pte_t *ptep, pgtable_t token,
+ 				 unsigned long addr, void *data)
+ {
+ 	struct remap_data *rmd = data;
+-	pte_t pte = pte_mkspecial(mfn_pte(*rmd->mfn, rmd->prot));
++	pte_t pte = pte_mkspecial(mfn_pte(*rmd->pfn, rmd->prot));
+ 
+-	/* If we have a contiguous range, just update the mfn itself,
+-	   else update pointer to be "next mfn". */
++	/*
++	 * If we have a contiguous range, just update the pfn itself,
++	 * else update pointer to be "next pfn".
++	 */
+ 	if (rmd->contiguous)
+-		(*rmd->mfn)++;
++		(*rmd->pfn)++;
+ 	else
+-		rmd->mfn++;
++		rmd->pfn++;
+ 
+-	rmd->mmu_update->ptr = virt_to_machine(ptep).maddr | MMU_NORMAL_PT_UPDATE;
++	rmd->mmu_update->ptr = virt_to_machine(ptep).maddr;
++	rmd->mmu_update->ptr |= rmd->no_translate ?
++		MMU_PT_UPDATE_NO_TRANSLATE :
++		MMU_NORMAL_PT_UPDATE;
+ 	rmd->mmu_update->val = pte_val_ma(pte);
+ 	rmd->mmu_update++;
+ 
+ 	return 0;
+ }
+ 
+-static int do_remap_gfn(struct vm_area_struct *vma,
++static int do_remap_pfn(struct vm_area_struct *vma,
+ 			unsigned long addr,
+-			xen_pfn_t *gfn, int nr,
++			xen_pfn_t *pfn, int nr,
+ 			int *err_ptr, pgprot_t prot,
+-			unsigned domid,
++			unsigned int domid,
++			bool no_translate,
+ 			struct page **pages)
+ {
+ 	int err = 0;
+@@ -104,11 +111,14 @@ static int do_remap_gfn(struct vm_area_struct *vma,
+ 
+ 	BUG_ON(!((vma->vm_flags & (VM_PFNMAP | VM_IO)) == (VM_PFNMAP | VM_IO)));
+ 
+-	rmd.mfn = gfn;
++	rmd.pfn = pfn;
+ 	rmd.prot = prot;
+-	/* We use the err_ptr to indicate if there we are doing a contiguous
+-	 * mapping or a discontigious mapping. */
++	/*
++	 * We use the err_ptr to indicate if there we are doing a contiguous
++	 * mapping or a discontigious mapping.
++	 */
+ 	rmd.contiguous = !err_ptr;
++	rmd.no_translate = no_translate;
+ 
+ 	while (nr) {
+ 		int index = 0;
+@@ -119,7 +129,7 @@ static int do_remap_gfn(struct vm_area_struct *vma,
+ 
+ 		rmd.mmu_update = mmu_update;
+ 		err = apply_to_page_range(vma->vm_mm, addr, range,
+-					  remap_area_mfn_pte_fn, &rmd);
++					  remap_area_pfn_pte_fn, &rmd);
+ 		if (err)
+ 			goto out;
+ 
+@@ -170,7 +180,8 @@ int xen_remap_domain_gfn_range(struct vm_area_struct *vma,
+ 			       pgprot_t prot, unsigned domid,
+ 			       struct page **pages)
+ {
+-	return do_remap_gfn(vma, addr, &gfn, nr, NULL, prot, domid, pages);
++	return do_remap_pfn(vma, addr, &gfn, nr, NULL, prot, domid, false,
++			    pages);
+ }
+ EXPORT_SYMBOL_GPL(xen_remap_domain_gfn_range);
+ 
+@@ -185,10 +196,25 @@ int xen_remap_domain_gfn_array(struct vm_area_struct *vma,
+ 	 * cause of "wrong memory was mapped in".
+ 	 */
+ 	BUG_ON(err_ptr == NULL);
+-	return do_remap_gfn(vma, addr, gfn, nr, err_ptr, prot, domid, pages);
++	return do_remap_pfn(vma, addr, gfn, nr, err_ptr, prot, domid,
++			    false, pages);
+ }
+ EXPORT_SYMBOL_GPL(xen_remap_domain_gfn_array);
+ 
++int xen_remap_domain_mfn_array(struct vm_area_struct *vma,
++			       unsigned long addr,
++			       xen_pfn_t *mfn, int nr,
++			       int *err_ptr, pgprot_t prot,
++			       unsigned int domid, struct page **pages)
++{
++	if (xen_feature(XENFEAT_auto_translated_physmap))
++		return -EOPNOTSUPP;
++
++	return do_remap_pfn(vma, addr, mfn, nr, err_ptr, prot, domid,
++			    true, pages);
++}
++EXPORT_SYMBOL_GPL(xen_remap_domain_mfn_array);
++
+ /* Returns: 0 success */
+ int xen_unmap_domain_gfn_range(struct vm_area_struct *vma,
+ 			       int numpgs, struct page **pages)
+diff --git a/drivers/xen/privcmd.c b/drivers/xen/privcmd.c
+index feca75b..39562be 100644
+--- a/drivers/xen/privcmd.c
++++ b/drivers/xen/privcmd.c
+@@ -33,6 +33,7 @@
+ #include <xen/xen.h>
+ #include <xen/privcmd.h>
+ #include <xen/interface/xen.h>
++#include <xen/interface/memory.h>
+ #include <xen/interface/hvm/dm_op.h>
+ #include <xen/features.h>
+ #include <xen/page.h>
+@@ -725,6 +726,134 @@ static long privcmd_ioctl_restrict(struct file *file, void __user *udata)
+ 	return 0;
+ }
+ 
++struct remap_pfn {
++	struct mm_struct *mm;
++	struct page **pages;
++	pgprot_t prot;
++	unsigned long i;
++};
++
++static int remap_pfn_fn(pte_t *ptep, pgtable_t token, unsigned long addr,
++			void *data)
++{
++	struct remap_pfn *r = data;
++	struct page *page = r->pages[r->i];
++	pte_t pte = pte_mkspecial(pfn_pte(page_to_pfn(page), r->prot));
++
++	set_pte_at(r->mm, addr, ptep, pte);
++	r->i++;
++
++	return 0;
++}
++
++static long privcmd_ioctl_mmap_resource(struct file *file, void __user *udata)
++{
++	struct privcmd_data *data = file->private_data;
++	struct mm_struct *mm = current->mm;
++	struct vm_area_struct *vma;
++	struct privcmd_mmap_resource kdata;
++	xen_pfn_t *pfns = NULL;
++	struct xen_mem_acquire_resource xdata;
++	int rc;
++
++	if (copy_from_user(&kdata, udata, sizeof(kdata)))
++		return -EFAULT;
++
++	/* If restriction is in place, check the domid matches */
++	if (data->domid != DOMID_INVALID && data->domid != kdata.dom)
++		return -EPERM;
++
++	down_write(&mm->mmap_sem);
++
++	vma = find_vma(mm, kdata.addr);
++	if (!vma || vma->vm_ops != &privcmd_vm_ops) {
++		rc = -EINVAL;
++		goto out;
++	}
++
++	pfns = kcalloc(kdata.num, sizeof(*pfns), GFP_KERNEL);
++	if (!pfns) {
++		rc = -ENOMEM;
++		goto out;
++	}
++
++	if (xen_feature(XENFEAT_auto_translated_physmap)) {
++		unsigned int nr = DIV_ROUND_UP(kdata.num, XEN_PFN_PER_PAGE);
++		struct page **pages;
++		unsigned int i;
++
++		rc = alloc_empty_pages(vma, nr);
++		if (rc < 0)
++			goto out;
++
++		pages = vma->vm_private_data;
++		for (i = 0; i < kdata.num; i++) {
++			xen_pfn_t pfn =
++				page_to_xen_pfn(pages[i / XEN_PFN_PER_PAGE]);
++
++			pfns[i] = pfn + (i % XEN_PFN_PER_PAGE);
++		}
++	} else
++		vma->vm_private_data = PRIV_VMA_LOCKED;
++
++	memset(&xdata, 0, sizeof(xdata));
++	xdata.domid = kdata.dom;
++	xdata.type = kdata.type;
++	xdata.id = kdata.id;
++	xdata.frame = kdata.idx;
++	xdata.nr_frames = kdata.num;
++	set_xen_guest_handle(xdata.frame_list, pfns);
++
++	xen_preemptible_hcall_begin();
++	rc = HYPERVISOR_memory_op(XENMEM_acquire_resource, &xdata);
++	xen_preemptible_hcall_end();
++
++	if (rc)
++		goto out;
++
++	if (xen_feature(XENFEAT_auto_translated_physmap)) {
++		struct remap_pfn r = {
++			.mm = vma->vm_mm,
++			.pages = vma->vm_private_data,
++			.prot = vma->vm_page_prot,
++		};
++
++		rc = apply_to_page_range(r.mm, kdata.addr,
++					 kdata.num << PAGE_SHIFT,
++					 remap_pfn_fn, &r);
++	} else {
++		unsigned int domid =
++			(xdata.flags & XENMEM_rsrc_acq_caller_owned) ?
++			DOMID_SELF : kdata.dom;
++		int num;
++
++		num = xen_remap_domain_mfn_array(vma,
++						 kdata.addr & PAGE_MASK,
++						 pfns, kdata.num, (int *)pfns,
++						 vma->vm_page_prot,
++						 domid,
++						 vma->vm_private_data);
++		if (num < 0)
++			rc = num;
++		else if (num != kdata.num) {
++			unsigned int i;
++
++			for (i = 0; i < num; i++) {
++				rc = pfns[i];
++				if (rc < 0)
++					break;
++			}
++		} else
++			rc = 0;
++	}
++
++out:
++	up_write(&mm->mmap_sem);
++	kfree(pfns);
++
++	return rc;
++}
++
+ static long privcmd_ioctl(struct file *file,
+ 			  unsigned int cmd, unsigned long data)
+ {
+@@ -756,6 +885,10 @@ static long privcmd_ioctl(struct file *file,
+ 		ret = privcmd_ioctl_restrict(file, udata);
+ 		break;
+ 
++	case IOCTL_PRIVCMD_MMAP_RESOURCE:
++		ret = privcmd_ioctl_mmap_resource(file, udata);
++		break;
++
+ 	default:
+ 		break;
+ 	}
+diff --git a/include/uapi/xen/privcmd.h b/include/uapi/xen/privcmd.h
+index 39d3e7b..d202955 100644
+--- a/include/uapi/xen/privcmd.h
++++ b/include/uapi/xen/privcmd.h
+@@ -89,6 +89,15 @@ struct privcmd_dm_op {
+ 	const struct privcmd_dm_op_buf __user *ubufs;
+ };
+ 
++struct privcmd_mmap_resource {
++	domid_t dom;
++	__u32 type;
++	__u32 id;
++	__u32 idx;
++	__u64 num;
++	__u64 addr;
++};
++
+ /*
+  * @cmd: IOCTL_PRIVCMD_HYPERCALL
+  * @arg: &privcmd_hypercall_t
+@@ -114,5 +123,7 @@ struct privcmd_dm_op {
+ 	_IOC(_IOC_NONE, 'P', 5, sizeof(struct privcmd_dm_op))
+ #define IOCTL_PRIVCMD_RESTRICT					\
+ 	_IOC(_IOC_NONE, 'P', 6, sizeof(domid_t))
++#define IOCTL_PRIVCMD_MMAP_RESOURCE				\
++	_IOC(_IOC_NONE, 'P', 7, sizeof(struct privcmd_mmap_resource))
+ 
+ #endif /* __LINUX_PUBLIC_PRIVCMD_H__ */
+diff --git a/include/xen/interface/memory.h b/include/xen/interface/memory.h
+index 583dd93..4c5751c 100644
+--- a/include/xen/interface/memory.h
++++ b/include/xen/interface/memory.h
+@@ -265,4 +265,70 @@ struct xen_remove_from_physmap {
+ };
+ DEFINE_GUEST_HANDLE_STRUCT(xen_remove_from_physmap);
+ 
++/*
++ * Get the pages for a particular guest resource, so that they can be
++ * mapped directly by a tools domain.
++ */
++#define XENMEM_acquire_resource 28
++struct xen_mem_acquire_resource {
++    /* IN - The domain whose resource is to be mapped */
++    domid_t domid;
++    /* IN - the type of resource */
++    uint16_t type;
++
++#define XENMEM_resource_ioreq_server 0
++#define XENMEM_resource_grant_table 1
++
++    /*
++     * IN - a type-specific resource identifier, which must be zero
++     *      unless stated otherwise.
++     *
++     * type == XENMEM_resource_ioreq_server -> id == ioreq server id
++     * type == XENMEM_resource_grant_table -> id defined below
++     */
++    uint32_t id;
++
++#define XENMEM_resource_grant_table_id_shared 0
++#define XENMEM_resource_grant_table_id_status 1
++
++    /* IN/OUT - As an IN parameter number of frames of the resource
++     *          to be mapped. However, if the specified value is 0 and
++     *          frame_list is NULL then this field will be set to the
++     *          maximum value supported by the implementation on return.
++     */
++    uint32_t nr_frames;
++    /*
++     * OUT - Must be zero on entry. On return this may contain a bitwise
++     *       OR of the following values.
++     */
++    uint32_t flags;
++
++    /* The resource pages have been assigned to the calling domain */
++#define _XENMEM_rsrc_acq_caller_owned 0
++#define XENMEM_rsrc_acq_caller_owned (1u << _XENMEM_rsrc_acq_caller_owned)
++
++    /*
++     * IN - the index of the initial frame to be mapped. This parameter
++     *      is ignored if nr_frames is 0.
++     */
++    uint64_t frame;
++
++#define XENMEM_resource_ioreq_server_frame_bufioreq 0
++#define XENMEM_resource_ioreq_server_frame_ioreq(n) (1 + (n))
++
++    /*
++     * IN/OUT - If the tools domain is PV then, upon return, frame_list
++     *          will be populated with the MFNs of the resource.
++     *          If the tools domain is HVM then it is expected that, on
++     *          entry, frame_list will be populated with a list of GFNs
++     *          that will be mapped to the MFNs of the resource.
++     *          If -EIO is returned then the frame_list has only been
++     *          partially mapped and it is up to the caller to unmap all
++     *          the GFNs.
++     *          This parameter may be NULL if nr_frames is 0.
++     */
++    GUEST_HANDLE(xen_pfn_t) frame_list;
++};
++DEFINE_GUEST_HANDLE_STRUCT(xen_mem_acquire_resource);
++
+ #endif /* __XEN_PUBLIC_MEMORY_H__ */
+diff --git a/include/xen/interface/xen.h b/include/xen/interface/xen.h
+index 4f4830e..8bfb242 100644
+--- a/include/xen/interface/xen.h
++++ b/include/xen/interface/xen.h
+@@ -265,9 +265,10 @@
+  *
+  * PAT (bit 7 on) --> PWT (bit 3 on) and clear bit 7.
+  */
+-#define MMU_NORMAL_PT_UPDATE      0 /* checked '*ptr = val'. ptr is MA.       */
+-#define MMU_MACHPHYS_UPDATE       1 /* ptr = MA of frame to modify entry for  */
+-#define MMU_PT_UPDATE_PRESERVE_AD 2 /* atomically: *ptr = val | (*ptr&(A|D)) */
++#define MMU_NORMAL_PT_UPDATE       0 /* checked '*ptr = val'. ptr is MA.      */
++#define MMU_MACHPHYS_UPDATE        1 /* ptr = MA of frame to modify entry for */
++#define MMU_PT_UPDATE_PRESERVE_AD  2 /* atomically: *ptr = val | (*ptr&(A|D)) */
++#define MMU_PT_UPDATE_NO_TRANSLATE 3 /* checked '*ptr = val'. ptr is MA.      */
+ 
+ /*
+  * MMU EXTENDED OPERATIONS
+diff --git a/include/xen/xen-ops.h b/include/xen/xen-ops.h
+index a95e65e..95d4ca6 100644
+--- a/include/xen/xen-ops.h
++++ b/include/xen/xen-ops.h
+@@ -62,7 +62,7 @@ static inline void xen_destroy_contiguous_region(phys_addr_t pstart,
+ struct vm_area_struct;
+ 
+ /*
+- * xen_remap_domain_gfn_array() - map an array of foreign frames
++ * xen_remap_domain_gfn_array() - map an array of foreign frames by gfn
+  * @vma:     VMA to map the pages into
+  * @addr:    Address at which to map the pages
+  * @gfn:     Array of GFNs to map
+@@ -85,6 +85,28 @@ int xen_remap_domain_gfn_array(struct vm_area_struct *vma,
+ 			       unsigned domid,
+ 			       struct page **pages);
+ 
++/*
++ * xen_remap_domain_mfn_array() - map an array of foreign frames by mfn
++ * @vma:     VMA to map the pages into
++ * @addr:    Address at which to map the pages
++ * @mfn:     Array of MFNs to map
++ * @nr:      Number entries in the MFN array
++ * @err_ptr: Returns per-MFN error status.
++ * @prot:    page protection mask
++ * @domid:   Domain owning the pages
++ * @pages:   Array of pages if this domain has an auto-translated physmap
++ *
++ * @mfn and @err_ptr may point to the same buffer, the MFNs will be
++ * overwritten by the error codes after they are mapped.
++ *
++ * Returns the number of successfully mapped frames, or a -ve error
++ * code.
++ */
++int xen_remap_domain_mfn_array(struct vm_area_struct *vma,
++			       unsigned long addr, xen_pfn_t *mfn, int nr,
++			       int *err_ptr, pgprot_t prot,
++			       unsigned int domid, struct page **pages);
++
+ /* xen_remap_domain_gfn_range() - map a range of foreign frames
+  * @vma:     VMA to map the pages into
+  * @addr:    Address at which to map the pages
+-- 
+2.7.4
+

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas_%.bbappend
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas_%.bbappend
@@ -15,6 +15,7 @@ SRC_URI_append_rcar = " \
     file://salvator-generic-doma.dts;subdir=git/arch/${ARCH}/boot/dts/renesas \
     file://salvator-generic-domu.dts;subdir=git/arch/${ARCH}/boot/dts/renesas \
     file://xen-chosen.dtsi;subdir=git/arch/${ARCH}/boot/dts/renesas \
+    file://0001-xen-privcmd-add-IOCTL_PRIVCMD_MMAP_RESOURCE.patch \
 "
 
 KERNEL_DEVICETREE_append_rcar = " \


### PR DESCRIPTION
The VirtIO feature (which this PR adds) allows us to run either DomU or DomA on a VirtIO block device instead of using a traditional Xen PV block device (this PR also introduces a recipe for a completely new entity which is the virtio-disk backend).
This PR was successfully tested on a system with DomU and DomA.
It is a [WIP] because:
- This support means to be disabled by default for now. So the last patch should be dropped (I left it in current PR just for
  a visibility reason)
- I used ioreq_4.14_v5 branch at my Xen repo so far since the product is based on v4.14 release while my IOREQ patch series
  on v4.15-rc. So either the product should be migrated to v4.15-rc (preferred) or a series should be back-ported to release.  