### PR TITLE
domd: Allow pci-back to run in DomD

### DIFF
--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas/0001-HACK-Allow-pci-back-run-in-DomD.patch
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas/0001-HACK-Allow-pci-back-run-in-DomD.patch
@@ -1,0 +1,28 @@
+From fb26e15262911e124bc7ddf3aa4d388ea6fb8fe3 Mon Sep 17 00:00:00 2001
+From: Oleksandr Andrushchenko <andr2000@gmail.com>
+Date: Tue, 8 Dec 2020 10:04:25 +0200
+Subject: [PATCH] [HACK] Allow pci-back run in DomD
+
+Signed-off-by: Oleksandr Andrushchenko <andr2000@gmail.com>
+---
+ drivers/xen/xen-pciback/pci_stub.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/drivers/xen/xen-pciback/pci_stub.c b/drivers/xen/xen-pciback/pci_stub.c
+index 7f51524868f9..a0b43d9fa878 100644
+--- a/drivers/xen/xen-pciback/pci_stub.c
++++ b/drivers/xen/xen-pciback/pci_stub.c
+@@ -1609,8 +1609,10 @@ static int __init xen_pcibk_init(void)
+ {
+ 	int err;
+ 
++#if 0
+ 	if (!xen_initial_domain())
+ 		return -ENODEV;
++#endif
+ 
+ 	err = xen_pcibk_config_init();
+ 	if (err)
+-- 
+2.17.1
+

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas_%.bbappend
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas_%.bbappend
@@ -24,6 +24,7 @@ SRC_URI_append_rcar = " \
     file://0001-HACK-Allow-DomD-enumerate-PCI-devices.patch \
     file://0001-HACK-Make-rcar-gen3-PCI-work-through-ECAM.patch \
     file://0001-arm-pci-Make-xen-pciback-driver-work-on-ARM.patch \
+    file://0001-HACK-Allow-pci-back-run-in-DomD.patch \
 "
 
 KERNEL_DEVICETREE_append_rcar = " \


### PR DESCRIPTION
pci-back has a check if it runs in the initial domain, e.g. Domain-0,
which is not the case when it runs in the driver domain DomD.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>