### PR TITLE
Describe PCI device(s)-IOMMU(s) connection using DT PCI-IOMMU bindings

### DIFF
--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domd-salvator-x-h3-4x2g.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domd-salvator-x-h3-4x2g.cfg
@@ -140,8 +140,6 @@ dtdev = [
     "/soc/gsx_pv3_domd",
     "/soc/fcpcs_vc0",
     "/soc/fcpcs_vc1",
-# DomD is not supposed to use PCI devices in favor of DomU
-#    "/soc/pcie@fe000000",
 ]
 
 irqs = [

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domu-generic-h3-4x2g.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/domu-generic-h3-4x2g.cfg
@@ -21,8 +21,6 @@ dtdev = [
     "/soc/gsx_pv1_domu",
     "/soc/gsx_pv2_domu",
     "/soc/gsx_pv3_domu",
-# DomD is not supposed to use PCI devices in favor of DomU
-    "/soc/pcie@fe000000",
 ]
 
 # Kernel command line options

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas/r8a7795-salvator-x-4x2g-dom0.dts
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas/r8a7795-salvator-x-4x2g-dom0.dts
@@ -274,7 +274,8 @@
 };
 
 &pciec0 {
-	iommus = <&ipmmu_hc 0>;
+    iommu-map = <0x0 &ipmmu_hc 0x0 0x1>;
+    iommu-map-mask = <0x0>;
 };
 
 &ehci0 {


### PR DESCRIPTION
Taking into the account that on Gen3 the IPMMU can't distinguish between
different PCI Functions we propose the following settings:

&pciec0 {
    iommu-map = <0x0 &ipmmu_hc 0x0 0x1>;
    iommu-map-mask = <0x0>;
};

which means that all Requester IDs will be mapped to the uTLB 0
of ipmmu_hc.

According to:
https://www.kernel.org/doc/Documentation/devicetree/bindings/pci/pci-iommu.txt

Signed-off-by: Oleksandr Tyshchenko <oleksandr_tyshchenko@epam.com>