### PR TITLE
qemu/dom0: Build Realtek 8139cp as a kernel module

### DIFF
--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-core/images/core-image-thin-initramfs.bbappend
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-core/images/core-image-thin-initramfs.bbappend
@@ -24,6 +24,7 @@ IMAGE_INSTALL_append_qemu-xen = "\
     openssh-scp \
     openssh-sshd \
     haveged \
+    kernel-modules \
 "
 
 IMAGE_INSTALL_remove_qemu-xen = "\

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-kernel/linux/linux-generic-armv8.bbappend
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-kernel/linux/linux-generic-armv8.bbappend
@@ -18,11 +18,15 @@ LIC_FILES_CHKSUM_qemu-xen = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46
 SRC_URI_qemu-xen = " \
     git://github.com/xen-troops/linux.git;branch=${BRANCH} \
     file://qemu-xen/defconfig;destsuffix=defconfig \
+    file://qemu-xen/8139cp.cfg \
 "
 
 KERNEL_DEVICETREE_qemu-xen = " \
     xilinx/zynqmp-zcu102-rev1.0.dtb \
 "
+
+KERNEL_MODULE_PROBECONF_qemu-xen += "8139cp"
+module_conf_8139cp_qemu-xen = "blacklist 8139cp"
 
 FILES_${KERNEL_PACKAGE_NAME}-base += " \
     ${nonarch_base_libdir}/modules/${KERNEL_VERSION}/modules.builtin.modinfo \

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-kernel/linux/linux-generic-armv8/qemu-xen/8139cp.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-kernel/linux/linux-generic-armv8/qemu-xen/8139cp.cfg
@@ -1,0 +1,1 @@
+CONFIG_8139CP=m


### PR DESCRIPTION
Build Linux kernel module for:
Ethernet controller: Realtek Semiconductor Co., Ltd. RTL-8100/8101L/8139 PCI Fast Ethernet Adapter (rev 20)
instead of having it built-in.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>