### PR TITLE
domd: meta-renesas: Apply rcar-gen3-adas patch only for h3ulcb-4x2g-kf

### DIFF
--- a/recipes-domd/domd-image-weston/domd-image-weston.bbappend
+++ b/recipes-domd/domd-image-weston/domd-image-weston.bbappend
@@ -85,11 +85,11 @@ XT_QUIRK_PATCH_SRC_URI_rcar = "\
     file://0001-recipes-kernel-Load-multimedia-related-modules-autom.patch;patchdir=meta-renesas \
     file://0001-Modify-gstvspfilter-salvator-x_r8a7795.conf-to-use-v.patch;patchdir=meta-renesas \
     file://0001-armtf-Clarify-check-for-the-h3ulcb-based-machines-in.patch;patchdir=meta-renesas \
-    file://0001-armtf-Add-missing-ADDITIONAL_ATFW_OPT-in-do_ipl_opt_.patch;patchdir=meta-rcar \
 "
 
 XT_QUIRK_PATCH_SRC_URI_append_h3ulcb-4x2g-kf = "\
 	file://0001-Kingfisher-remove-linux-renesas-uapi.patch;patchdir=meta-rcar \
+    file://0001-armtf-Add-missing-ADDITIONAL_ATFW_OPT-in-do_ipl_opt_.patch;patchdir=meta-rcar \
 "
 
 XT_BB_LOCAL_CONF_FILE_rcar = "meta-xt-prod-extra/doc/local.conf.rcar-domd-image-weston"


### PR DESCRIPTION
Patch for meta-rcar-gen3-adas is only applicable for h3ulcb-4x2g-kf.
Assign patch to coresponding SRC_URI.

Signed-off-by: Valerii Chubar <valerii_chubar@epam.com>