### PR TITLE
Dockerfile to build prod-devel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,78 @@
+
+FROM ubuntu:16.04
+
+ARG BUILDBOT
+ARG PUB_KEY
+ARG PRIV_KEY
+ARG CONFIG
+ARG BUILBOT_MAIL
+ARG PROD
+ARG MACHINE
+ARG BRANCH
+
+RUN apt-get update
+# install the requiured prerequisites
+RUN apt-get install gcc-5-aarch64-linux-gnu gcc-aarch64-linux-gnu -y
+RUN apt-get remove gcc-5-multilib gcc-multilib
+RUN apt-get install -y vim \
+    cpio gawk wget diffstat texinfo chrpath socat libsdl1.2-dev \
+    python-crypto repo checkpolicy python-git python-github \
+    python-ctypeslib bzr pigz m4 lftp openjdk-8-jdk git-core \
+    gnupg flex bison gperf build-essential zip curl zlib1g-dev \
+    gcc-multilib g++-multilib libc6-dev-i386 lib32ncurses5-dev \
+    x11proto-core-dev libx11-dev lib32z-dev ccache libgl1-mesa-dev \
+    libxml2-utils xsltproc unzip python-clang-5.0 gcc-5 g++-5 bc \
+    python-pip python3-pyelftools python3-pip python3-crypto \
+    android-tools-fsutils libssl-dev \
+    sudo policykit-1 locales && \
+    dpkg-reconfigure locales  && \
+    locale-gen en_US.UTF-8 && \
+    update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8 && \
+    pip install pycryptodome && \
+    pip3 install pycryptodomex && \
+    mkdir -p /mnt/work/build && \
+    if [ "$BUILDBOT" != "root" ]; then \
+    useradd -ms /bin/bash "$BUILDBOT" && \
+    passwd -d $BUILDBOT && \
+    usermod -aG sudo "$BUILDBOT" && \
+    mkdir -p /home/"$BUILDBOT"/.ssh && \
+    chown -R "$BUILDBOT" /home/"$BUILDBOT" ; \
+    fi
+
+RUN chown -R "$BUILDBOT" /mnt/work && \
+    chown -R "$BUILDBOT" /usr/bin && \
+    chown root:root /usr/bin/sudo && chmod 4755 /usr/bin/sudo && \
+    echo "$BUILDBOT ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+
+COPY "$PRIV_KEY" /root/.ssh/
+COPY "$PUB_KEY" /root/.ssh/
+
+USER "$BUILDBOT"
+
+RUN curl https://storage.googleapis.com/git-repo-downloads/repo-1 > ~/repo && \
+    chmod a+x ~/repo && \
+    sudo cp ~/repo /usr/bin/ 
+
+RUN echo "export LANG=en_US.UTF-8" >> ~/.profile && \
+    git config --global user.email "$BUILBOT_MAIL" && \
+    git config --global user.name "$BUILDBOT" && \
+    ssh-keyscan github.com >> ~/.ssh/known_hosts && \
+    ssh-keyscan gitpct.epam.com >> ~/.ssh/known_hosts && \
+    if [ "$HOME" != "/root" ]; then \
+      sudo cp /root/.ssh/"$PRIV_KEY" ~/.ssh/ && \
+      sudo cp /root/.ssh/"$PUB_KEY" ~/.ssh/ && \
+      sudo chown -R "$BUILDBOT" ~/.ssh/"$PRIV_KEY" && \
+      sudo chown -R "$BUILDBOT" ~/.ssh/"$PUB_KEY" ; \
+    fi
+
+
+RUN cd ~/ && git clone git@github.com:xen-troops/build-scripts.git && \
+    cd ~/build-scripts && \
+    python ./build_prod.py --build-type dailybuild --machine "$MACHINE" --product $PROD  --branch "$BRANCH" --with-local-conf --config ./$CONFIG && \
+    echo "#!/bin/bash" >> ./continue_build.sh && \
+    echo "python ./build_prod.py --build-type dailybuild --machine $MACHINE --product $PROD  --branch $BRANCH --with-local-conf --config ./$CONFIG --continue-build" >> ./continue_build.sh && \
+    chmod +x ./continue_build.sh
+    
+
+USER root
+

--- a/build_docker.sh
+++ b/build_docker.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# copy the keys into local folder if the id_rsa* files are not in the local directory
+
+ssh_files=("id_rsa" "id_rsa.pub")
+index=0
+
+for file_name in ${ssh_files[@]}; do
+
+    if [ ! -f "./$file_name" ] && [ -f "$HOME/.ssh/${file_name}" ]; then
+	cp ${HOME}/.ssh/${file_name} ./
+	let "index=index+1"
+    fi
+
+done
+
+len=${#ssh_files[@]}
+
+if [ $index ne $len ]; then
+
+   echo "The id_rsa and/or id_rsa.pub - not found"
+   exit
+
+fi
+
+
+
+docker build --build-arg BUILDBOT="iusyk" --build-arg PUB_KEY="${ssh_files[1]}" --build-arg PRIV_KEY="${ssh_files[0]}" --build-arg CONFIG="$5" --build-arg BUILBOT_MAIL="$1" --build-arg BRANCH="$3" --build-arg PROD="$2" --build-arg MACHINE="$4"  -t "$2-image" .
+
+back_pid=$!
+wait $back_pid
+
+for file_name in ${ssh_files[@]}; do
+
+    if [ -f "./$file_name" ]; then
+        rm ./${file_name}
+    fi
+
+done 

--- a/make_prod_devel_src_docker.sh
+++ b/make_prod_devel_src_docker.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+./build_docker.sh $1 "devel-src" "master" "salvator-x-h3-4x2g"  "gcp-build-server-devel.cfg"


### PR DESCRIPTION
Now it is possible to create the docker image to build the xen-troops products.
Important: the image is created under the current user.
The script build_docker.sh gathers the public and private key from ~/.ssh to run the
build of the image.

There are three scripts have been implemented to build the docker image.

-Dockerfile contains the intructions to build the docker image
The script has the following input parameters
BUILDBOT - user name
PUB_KEY - file with the ssh public key
PRIV_KEY - file with the ssh private key
CONFIG - config file to build the product(must be taken from https://github.com/xen-troops/build-scripts)
BUILBOT_MAIL - user's email
PROD - product name
MACHINE - target machine name (one from: salvator-x-h3, salvator-xs-h3, salvator-x-h3-4x2g, salvator-x-m3, h3ulcb-4x2g-kf, h3ulcb-cb)
BRANCH - github branch to fetch the https://github.com/xen-troops/meta-xt-products

The final docker-repository name is $PROD-image

Sample:
docker build --build-arg BUILDBOT=$(whoami) --build-arg PUB_KEY="id_rsa.pub" --build-arg PRIV_KEY="id_rsa" \
      --build-arg CONFIG="gcp-build-server-devel.cfg" --build-arg BUILBOT_MAIL="user@epam.com" --build-arg BRANCH="master"
      --build-arg PROD="devel-src" --build-arg MACHINE="salvator-x-h3-4x2g"  -t "devel-src-image" .

-build_docker.sh
Copies the ssh keys
Build docker
Remove the temporary files

There are five input parameters
1.user's email
2.product name
3.branch od the git repository to fetch the required layers(github.com:xen-troops/meta-xt-products)
4.machine name
5.name of the config file to generate the local.conf

Sample: ./build_docker.sh "user@epam.com" "devel-src" "master" "salvator-x-h3-4x2g"  "gcp-build-server-devel.cfg"

Where
user@epam.com is user's email
devel-src is the name of the product prod-devel-src
master is the branch to fetch the meta-xt-products
salvator-x-h3-4x2g is the target machine name
gcp-build-server-devel.cfg is the config file from build-scripts repository.

Result: docker-image 'devel-src-image' is generated.
The image has the fetcher yocto layers placed in /mnt/work/build
xt-distro
meta-xt-images
meta-xt-prod-devel

-make_prod_devel_src_docker.sh
Script is the helper to run the build_docker.sh.
Script has one input parameter - user's email.
The rest parameters can be changed inside the script.

To start the build, it is the following steps must be done
1.docker run [image id] -it
2.sudo su [user name]
3.cd ~/build-scripts
4.run:'build_continue.sh'
5.the build results can be found at:/mnt/work/build/build/deploy

Use command docker commit to save your changes
See 'https://docs.docker.com/' for the details.

Signed-off-by: Ihor Usyk <ihor_usyk@epam.com>