### PR TITLE
visservice: Move visservice host to base-files

### DIFF
--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-core/base-files/base-files_%.bbappend
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-core/base-files/base-files_%.bbappend
@@ -9,4 +9,7 @@ do_install_append () {
 	echo "	shopt -s checkwinsize" >> ${D}${sysconfdir}/profile
 	echo "  resize 1> /dev/null" >> ${D}${sysconfdir}/profile
 	echo "fi" >> ${D}${sysconfdir}/profile
+	if [ ! -z "${AOS_VIS_PLUGINS}" ]; then
+		echo "192.168.0.1 wwwivi" >> ${D}${sysconfdir}/hosts
+	fi
 }

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-core/netbase/netbase_%.bbappend
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-core/netbase/netbase_%.bbappend
@@ -1,6 +1,0 @@
-
-do_install_append () {
-    if [ ! -z "${AOS_VIS_PLUGINS}" ]; then
-	echo "192.168.0.1 wwwivi" >> ${D}${sysconfdir}/hosts
-    fi
-}


### PR DESCRIPTION
Move visservice host to base-files to prevent build
time race conditions between base-files and netbase.

Signed-off-by: Andrii Chepurnyi <andrii_chepurnyi@epam.com>