### PR TITLE
domu: remove psplash

### DIFF
--- a/recipes-domu/domu-image-weston/files/meta-xt-prod-extra/recipes-graphics/images/core-image-weston.bbappend
+++ b/recipes-domu/domu-image-weston/files/meta-xt-prod-extra/recipes-graphics/images/core-image-weston.bbappend
@@ -16,6 +16,8 @@ IMAGE_INSTALL_remove = " \
     libx11-locale \
 "
 
+SPLASH = ""
+
 # Use only provided proprietary graphic modules
 IMAGE_INSTALL_remove = " \
     packagegroup-graphics-renesas-proprietary \


### PR DESCRIPTION
Disable psplash from installation, because it not functional.
It requires a frame buffer which is not available in DomU.

Signed-off-by: Valerii Chubar <valerii_chubar@epam.com>