### PR TITLE
Dom0: disable python-clang_5.0.post2.bb

### DIFF
--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/doc/local.conf.dom0-image-minimal-initramfs
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/doc/local.conf.dom0-image-minimal-initramfs
@@ -228,6 +228,7 @@ DISTRO_FEATURES_append = " pvcamera"
 DEPLOY_DIR = "${TMPDIR}/deploy"
 IMAGE_ROOTFS = "${TMPDIR}/rootfs"
 XT_SHARED_ROOTFS_DIR = "${IMAGE_ROOTFS}/shared_rootfs"
+BBMASK += "python-clang_5.0.post2.bb"
 
 include ${@d.getVar('XT_SHARED_ROOTFS_DIR', True) or ''}/local.conf.domd_machine.inc
 


### PR DESCRIPTION
The recipe is not required to build Dom0, and comes from domx.
If we leave as is, it is necessary to add the dependency at meta-python2,
to have a setup.bbclass, but what is useless in our case.
So, better to disable the recipe for Dom0.

Signed-off-by: Ihor Usyk <ihor_usyk@epam.com>