### PR TITLE
[WIP] audio: kf: Start pulseaudio after alsa-restore

### DIFF
--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-multimedia/pulseaudio/files/kingfisher/pulseaudio.service
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-multimedia/pulseaudio/files/kingfisher/pulseaudio.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=PulseAudio system server
+
+[Service]
+# We need to start pulse only when both audio cards
+# on kingfisher are properly set
+After=alsa-restore
+Type=notify
+ExecStart=/usr/bin/pulseaudio --daemonize=no --system --realtime --disallow-exit --log-target=journal
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
On Kingfisher sometimes we see that pulseaudio
is started before both audio cards are set.
This results in creation of incorrect sink.

This patch sets dependency for pulseaudio service
to start after alsa restored audio configuration.
After that pulse can properly execute commands
from system.pa.

Signed-off-by: Ruslan Shymkevych <ruslan_shymkevych@epam.com>