### PR TITLE
domd: Compile netevent in one thread

### DIFF
--- a/recipes-domd/domd-image-weston/domd-image-weston.bbappend
+++ b/recipes-domd/domd-image-weston/domd-image-weston.bbappend
@@ -178,6 +178,13 @@ configure_versions_rcar() {
     fi
 
     base_update_conf_value ${local_conf} XT_RCAR_PROPRIETARY_MULTIMEDIA_DIR "${XT_RCAR_PROPRIETARY_MULTIMEDIA_DIR}"
+
+    # We have netevent_%.bbappend that modifies
+    # meta-rcar-gen3-adas/recipes-support/netevent/netevent_git.bb
+    # and is intended to be used for Kingfisher only.
+    # For other boards we need to mask our bbappend to avoid
+    # warning "No recipes available for".
+    base_add_conf_value ${local_conf} BBMASK "recipes-support/netevent"
 }
 
 # In order to copy proprietary "multimedia" packages,

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-support/netevent/netevent_%.bbappend
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-support/netevent/netevent_%.bbappend
@@ -1,0 +1,3 @@
+# Sometimes we observe race during multithreaded compilation
+# so it's better to build netevent in one thread
+PARALLEL_MAKE = ""


### PR DESCRIPTION
Sometimes we observe race during multithreaded compilation
so it's better to build netevent in one thread.
