### PR TITLE
h3ulcb-4x2g-kf: Enable missing ipmmu_rt in dom0 device-tree

### DIFF
--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas/r8a7795-h3ulcb-4x2g-kf-dom0.dts
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas/r8a7795-h3ulcb-4x2g-kf-dom0.dts
@@ -122,6 +122,10 @@
 	status = "okay";
 };
 
+&ipmmu_rt {
+	status = "okay";
+};
+
 /*=========================== Bus masters linked to IPMMUS ===================*/
 
 &dmac0 {


### PR DESCRIPTION
Fix for:
xl create -c /xt/dom.cfg/domd.cfg
...
(XEN) XEN_DOMCTL_assign_dt_device: assign "/soc/dma-controller@ffc10000" to dom2 failed (-22)
libxl: error: libxl_create.c:1789:libxl__add_dtdevs: Domain 2:xc_assign_dtdevice failed: -1
libxl: error: libxl_create.c:1855:domcreate_attach_devices: Domain 2:unable to add none devices
(XEN) Removed GSX d2 (OSID 0)

Signed-off-by: Oleksandr Tyshchenko <oleksandr_tyshchenko@epam.com>