### PR TITLE
domd: Allow overwrite KERNEL_DEVICETREE variable

### DIFF
--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas_%.bbappend
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas_%.bbappend
@@ -21,7 +21,7 @@ SRC_URI_append_rcar = " \
     file://xen-chosen.dtsi;subdir=git/arch/${ARCH}/boot/dts/renesas \
 "
 
-KERNEL_DEVICETREE_append_rcar = " \
+KERNEL_DEVICETREE_prepend_rcar = " \
     renesas/salvator-generic-doma.dtb \
     renesas/salvator-generic-domu.dtb \
 "


### PR DESCRIPTION
KERNEL_DEVICETREE variable is used to generate the symbolic link for
the current domain. According to the current code the link will point
to the file which is at the end of the list of the variable.
But when a user specifies a device tree for a specific machine the
the link will still be pointing to the generic one.

Signed-off-by: Valerii Chubar <valerii_chubar@epam.com>