### PR TITLE
domd: Fix port used by VIS server to 443

### DIFF
--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-aos/aos-vis/files/aos_vis.cfg
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-aos/aos-vis/files/aos_vis.cfg
@@ -1,5 +1,5 @@
 {
-	"ServerURL": ":8088",
+	"ServerURL": ":443",
 	"VISCert": "/var/aos/vis/crypt/wwwivi.crt.pem",
 	"VISKey": "/var/aos/vis/crypt/wwwivi.key.pem",
 	"Adapters": [


### PR DESCRIPTION
According to
https://www.w3.org/TR/vehicle-information-service/#initialisation-of-the-websocket
default port should be 443.

Signed-off-by: Ruslan Shymkevych <ruslan_shymkevych@epam.com>