### PR TITLE
doma.cfg: Remove `ip=dhcp` from kernel command-line

### DIFF
--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/doma-generic-h3-4x2g.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/doma-generic-h3-4x2g.cfg
@@ -30,7 +30,7 @@ dt_passthrough_nodes = [
 ]
 
 # Kernel command line options
-extra = "ip=dhcp androidboot.boot_devices=51712 androidboot.hardware=xenvm init=/init ro rootwait console=hvc0 cma=256M@1-2G androidboot.selinux=permissive pvrsrvkm.DriverMode=1 androidboot.android_dt_dir=/proc/device-tree/firmware#1/android/ xt_page_pool=2097152 xt_cma=4194304"
+extra = "androidboot.boot_devices=51712 androidboot.hardware=xenvm init=/init ro rootwait console=hvc0 cma=256M@1-2G androidboot.selinux=permissive pvrsrvkm.DriverMode=1 androidboot.android_dt_dir=/proc/device-tree/firmware#1/android/ xt_page_pool=2097152 xt_cma=4194304"
 
 # Initial memory allocation (MB)
 memory = 5120

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/doma-generic-h3.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/doma-generic-h3.cfg
@@ -23,7 +23,7 @@ dt_passthrough_nodes = [
 ]
 
 # Kernel command line options
-extra = "ip=dhcp androidboot.boot_devices=51712 androidboot.hardware=xenvm init=/init ro rootwait console=hvc0 cma=256M@1-2G androidboot.selinux=permissive pvrsrvkm.DriverMode=1 androidboot.android_dt_dir=/proc/device-tree/firmware#1/android/ xt_page_pool=2097152 xt_cma=4194304"
+extra = "androidboot.boot_devices=51712 androidboot.hardware=xenvm init=/init ro rootwait console=hvc0 cma=256M@1-2G androidboot.selinux=permissive pvrsrvkm.DriverMode=1 androidboot.android_dt_dir=/proc/device-tree/firmware#1/android/ xt_page_pool=2097152 xt_cma=4194304"
 
 # Initial memory allocation (MB)
 memory = 2128

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/doma-generic-m3-2x4g.cfg
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/doma-generic-m3-2x4g.cfg
@@ -28,7 +28,7 @@ dt_passthrough_nodes = [
 ]
 
 # Kernel command line options
-extra = "ip=dhcp androidboot.boot_devices=51712 androidboot.hardware=xenvm init=/init ro rootwait console=hvc0 cma=256M@1-2G androidboot.selinux=permissive pvrsrvkm.DriverMode=1 androidboot.android_dt_dir=/proc/device-tree/firmware#1/android/ xt_page_pool=2097152 xt_cma=4194304"
+extra = "androidboot.boot_devices=51712 androidboot.hardware=xenvm init=/init ro rootwait console=hvc0 cma=256M@1-2G androidboot.selinux=permissive pvrsrvkm.DriverMode=1 androidboot.android_dt_dir=/proc/device-tree/firmware#1/android/ xt_page_pool=2097152 xt_cma=4194304"
 
 # Initial memory allocation (MB)
 memory = 5120


### PR DESCRIPTION
Assignment of IP is performed by user space, therefore we have
no need to send DHCP requests during the start of the kernel.

Signed-off-by: Ruslan Shymkevych <ruslan_shymkevych@epam.com>
Suggested-by: Volodymyr Babchuk <volodymyr_babchuk@epam.com>