### PR TITLE
domd: net: Make network settings according to guest installed

### DIFF
--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-connectivity/dnsmasq/dnsmasq_2.%.bbappend
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-connectivity/dnsmasq/dnsmasq_2.%.bbappend
@@ -18,9 +18,15 @@ do_install_append() {
 
     # Configure IP addresses for DomF, DomA, DomU.
     # MAC addresses are defined in /xt/dom.cfg/dom?.cfg
-    echo "dhcp-host=08:00:27:ff:cb:cd,domf,192.168.0.3,infinite" >> ${D}${sysconfdir}/dnsmasq.conf
-    echo "dhcp-host=08:00:27:ff:cb:ce,doma,192.168.0.4,infinite" >> ${D}${sysconfdir}/dnsmasq.conf
-    echo "dhcp-host=08:00:27:ff:cb:cf,domu,192.168.0.5,infinite" >> ${D}${sysconfdir}/dnsmasq.conf
+    if ${@bb.utils.contains('XT_GUESTS_INSTALL', 'domf', 'true', 'false', d)}; then
+        echo "dhcp-host=08:00:27:ff:cb:cd,domf,192.168.0.3,infinite" >> ${D}${sysconfdir}/dnsmasq.conf
+    fi
+    if ${@bb.utils.contains('XT_GUESTS_INSTALL', 'doma', 'true', 'false', d)}; then
+        echo "dhcp-host=08:00:27:ff:cb:ce,doma,192.168.0.4,infinite" >> ${D}${sysconfdir}/dnsmasq.conf
+    fi
+    if ${@bb.utils.contains('XT_GUESTS_INSTALL', 'domu', 'true', 'false', d)}; then
+        echo "dhcp-host=08:00:27:ff:cb:cf,domu,192.168.0.5,infinite" >> ${D}${sysconfdir}/dnsmasq.conf
+    fi
 
     # Use resolve.conf provided by systemd-resolved
     echo "resolv-file=/run/systemd/resolve/resolv.conf" >> ${D}${sysconfdir}/dnsmasq.conf

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/port-forward-systemd-networkd.conf
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-extended/guest-addons/files/port-forward-systemd-networkd.conf
@@ -1,9 +1,3 @@
 [Service]
 # SSH to dom0
 #ExecStartPost=+/usr/sbin/iptables -t nat -A PREROUTING -i eth0 -p tcp --dport 2023 -j DNAT --to-destination 192.168.0.7:22
-# SSH to domF
-ExecStartPost=+/usr/sbin/iptables -t nat -A PREROUTING -i eth0 -p tcp --dport 2022 -j DNAT --to-destination 192.168.0.3:22
-# ADB to domA
-ExecStartPost=+/usr/sbin/iptables -t nat -A PREROUTING -i eth0 -p tcp --dport 5555 -j DNAT --to-destination 192.168.0.4:5555
-# SSH to domU
-ExecStartPost=+/usr/sbin/iptables -t nat -A PREROUTING -i eth0 -p tcp --dport 2025 -j DNAT --to-destination 192.168.0.5:22

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-extended/guest-addons/guest-addons.bb
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-extended/guest-addons/guest-addons.bb
@@ -78,6 +78,24 @@ do_install() {
 
     install -d ${D}${sysconfdir}/systemd/system/systemd-networkd.service.d
     install -m 0644 ${WORKDIR}/port-forward-systemd-networkd.conf ${D}${sysconfdir}/systemd/system/systemd-networkd.service.d
+    if ${@bb.utils.contains('XT_GUESTS_INSTALL', 'domf', 'true', 'false', d)}; then
+        echo "\n# SSH to domF" \
+            >> ${D}${sysconfdir}/systemd/system/systemd-networkd.service.d/port-forward-systemd-networkd.conf
+        echo "ExecStartPost=+/usr/sbin/iptables -t nat -A PREROUTING -i eth0 -p tcp --dport 2022 -j DNAT --to-destination 192.168.0.3:22" \
+            >> ${D}${sysconfdir}/systemd/system/systemd-networkd.service.d/port-forward-systemd-networkd.conf
+    fi
+    if ${@bb.utils.contains('XT_GUESTS_INSTALL', 'doma', 'true', 'false', d)}; then
+        echo "\n# ADB to domA" \
+            >> ${D}${sysconfdir}/systemd/system/systemd-networkd.service.d/port-forward-systemd-networkd.conf
+        echo "ExecStartPost=+/usr/sbin/iptables -t nat -A PREROUTING -i eth0 -p tcp --dport 5555 -j DNAT --to-destination 192.168.0.4:5555" \
+            >> ${D}${sysconfdir}/systemd/system/systemd-networkd.service.d/port-forward-systemd-networkd.conf
+    fi
+    if ${@bb.utils.contains('XT_GUESTS_INSTALL', 'domu', 'true', 'false', d)}; then
+        echo "\n# SSH to domU" \
+            >> ${D}${sysconfdir}/systemd/system/systemd-networkd.service.d/port-forward-systemd-networkd.conf
+        echo "ExecStartPost=+/usr/sbin/iptables -t nat -A PREROUTING -i eth0 -p tcp --dport 2025 -j DNAT --to-destination 192.168.0.5:22" \
+            >> ${D}${sysconfdir}/systemd/system/systemd-networkd.service.d/port-forward-systemd-networkd.conf
+    fi
 
     install -d ${D}${sysconfdir}/systemd/system/systemd-networkd-wait-online.service.d
     install -m 0644 ${WORKDIR}/systemd-networkd-wait-online.conf ${D}${sysconfdir}/systemd/system/systemd-networkd-wait-online.service.d


### PR DESCRIPTION
This change removes not related records made to `dnsmasq.conf`
and `port-forward-systemd-networkd.conf`.

Signed-off-by: Ruslan Shymkevych <ruslan_shymkevych@epam.com>