### PR TITLE
URIs: replace git protocol with https one for the github sources.

### DIFF
--- a/recipes-dom0/dom0-image-rescue-initramfs/files/meta-xt-prod-extra/recipes-kernel/linux/linux-generic-armv8.bbappend
+++ b/recipes-dom0/dom0-image-rescue-initramfs/files/meta-xt-prod-extra/recipes-kernel/linux/linux-generic-armv8.bbappend
@@ -5,7 +5,7 @@ BRANCH = "master"
 SRCREV = "${AUTOREV}"
 
 SRC_URI_append = " \
-    git://github.com/xen-troops/linux.git;branch=${BRANCH} \
+    git://github.com/xen-troops/linux.git;branch=${BRANCH};protocol=https \
     file://defconfig \
   "
 

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-kernel/linux/linux-generic-armv8.bbappend
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-kernel/linux/linux-generic-armv8.bbappend
@@ -7,7 +7,7 @@ LINUX_VERSION = "5.4.72"
 KERNEL_FEATURES_remove = "cfg/virtio.scc"
 
 SRC_URI = " \
-    git://github.com/xen-troops/linux.git;branch=${BRANCH} \
+    git://github.com/xen-troops/linux.git;branch=${BRANCH};protocol=https \
     file://defconfig \
   "
 do_deploy_append () {

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-core/dbus/dbus-cxx_0.10.0.bbappend
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-core/dbus/dbus-cxx_0.10.0.bbappend
@@ -1,1 +1,1 @@
-SRC_URI = "git://github.com/dbus-cxx/${PN}.git;nobranch=1;tag=${PV}"
+SRC_URI = "git://github.com/dbus-cxx/${PN}.git;nobranch=1;tag=${PV};protocol=https"

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-extended/xt-log/xt-log_git.bbappend
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-extended/xt-log/xt-log_git.bbappend
@@ -1,2 +1,2 @@
-SRC_URI = "git://github.com/xen-troops/${PN}.git;branch=yocto-v4.7.0-xt0.1"
+SRC_URI = "git://github.com/xen-troops/${PN}.git;branch=yocto-v4.7.0-xt0.1;protocol=https"
 SRCREV = "${AUTOREV}"

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-graphics/wayland/wayland-ivi-extension_2.2.0_weston-8.bb
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-graphics/wayland/wayland-ivi-extension_2.2.0_weston-8.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=1f1a56bb2dadf5f2be8eb342acf4ed79"
 
 SRCREV = "e9c2fe4c5034a06b159cfd45dbd485755cbaf4c8"
 
-SRC_URI = "git://github.com/GENIVI/${BPN}.git;protocol=http \
+SRC_URI = "git://github.com/GENIVI/${BPN}.git;protocol=https \
     file://01-ivi-input-controller-update-to-weston-7.patch \
     file://02-ivi-id-agent-update-to-weston-7-header.patch \
     file://03-ivi-id-agent-update-dependencies-to-build-on-weston-8.patch \

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux-libc-headers/linux-libc-headers_%.bbappend
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux-libc-headers/linux-libc-headers_%.bbappend
@@ -1,4 +1,4 @@
-RENESAS_BSP_URL = "git://github.com/xen-troops/linux.git"
+RENESAS_BSP_URL = "git://github.com/xen-troops/linux.git;protocol=https"
 
 BRANCH = "v5.4.72/rcar-4.1.0.rc2-xt0.1"
 SRCREV = "${AUTOREV}"

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas_%.bbappend
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas_%.bbappend
@@ -2,7 +2,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
 require inc/xt_shared_env.inc
 
-RENESAS_BSP_URL = "git://github.com/xen-troops/linux.git"
+RENESAS_BSP_URL = "git://github.com/xen-troops/linux.git;protocol=https"
 
 BRANCH = "v5.4.72/rcar-4.1.0.rc2-xt0.1"
 SRCREV = "${AUTOREV}"

--- a/recipes-domu/domu-image-fusion/files/meta-xt-prod-extra/recipes-kernel/linux/linux-generic-armv8.bbappend
+++ b/recipes-domu/domu-image-fusion/files/meta-xt-prod-extra/recipes-kernel/linux/linux-generic-armv8.bbappend
@@ -7,7 +7,7 @@ SRCREV = "${AUTOREV}"
 LINUX_VERSION = "4.14.35"
 
 SRC_URI = " \
-    git://github.com/xen-troops/linux.git;branch=${BRANCH} \
+    git://github.com/xen-troops/linux.git;branch=${BRANCH};protocol=https \
     file://defconfig \
   "
 

--- a/recipes-domu/domu-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux-libc-headers/linux-libc-headers_%.bbappend
+++ b/recipes-domu/domu-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux-libc-headers/linux-libc-headers_%.bbappend
@@ -1,4 +1,4 @@
-RENESAS_BSP_URL = "git://github.com/xen-troops/linux.git"
+RENESAS_BSP_URL = "git://github.com/xen-troops/linux.git;protocol=https"
 
 BRANCH = "v5.4.72/rcar-4.1.0.rc2-xt0.1"
 SRCREV = "${AUTOREV}"

--- a/recipes-domu/domu-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas_%.bbappend
+++ b/recipes-domu/domu-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas_%.bbappend
@@ -2,7 +2,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
 require inc/xt_shared_env.inc
 
-RENESAS_BSP_URL = "git://github.com/xen-troops/linux.git"
+RENESAS_BSP_URL = "git://github.com/xen-troops/linux.git;protocol=https"
 
 BRANCH = "v5.4.72/rcar-4.1.0.rc2-xt0.1"
 SRCREV = "${AUTOREV}"


### PR DESCRIPTION
Use https instead of git because unauthenticated git protocol is disabled by github.

Signed-off-by: Ihor Usyk <ihor_usyk@epam.com>