### PR TITLE
URIs: replace git protocol with https one for the github sources.

### DIFF
--- a/recipes-dom0/dom0-image-rescue-initramfs/files/meta-xt-prod-extra/recipes-kernel/linux/linux-generic-armv8.bbappend
+++ b/recipes-dom0/dom0-image-rescue-initramfs/files/meta-xt-prod-extra/recipes-kernel/linux/linux-generic-armv8.bbappend
@@ -5,7 +5,7 @@ BRANCH = "master"
 SRCREV = "79b42d9fbd28b13d882a8c60b7e89b497662ae96"
 
 SRC_URI_append = " \
-    git://github.com/xen-troops/linux.git;branch=${BRANCH} \
+    git://github.com/xen-troops/linux.git;branch=${BRANCH};protocol=https \
     file://defconfig \
   "
 

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-kernel/linux/linux-generic-armv8.bbappend
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-kernel/linux/linux-generic-armv8.bbappend
@@ -5,7 +5,7 @@ SRCREV = "a49b495859d0d379ac4ca2068a5c42c1452df8b3"
 LINUX_VERSION = "4.14.75"
 
 SRC_URI = " \
-    git://github.com/xen-troops/linux.git;branch=${BRANCH} \
+    git://github.com/xen-troops/linux.git;branch=${BRANCH};protocol=https \
     file://defconfig \
   "
 do_deploy_append () {

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-core/dbus/dbus-cxx_0.10.0.bbappend
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-core/dbus/dbus-cxx_0.10.0.bbappend
@@ -1,1 +1,1 @@
-SRC_URI = "git://github.com/dbus-cxx/${PN}.git;nobranch=1;tag=${PV}"
+SRC_URI = "git://github.com/dbus-cxx/${PN}.git;nobranch=1;tag=${PV};protocol=https"

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-extended/libconfig/libconfig_1.5.bbappend
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-extended/libconfig/libconfig_1.5.bbappend
@@ -1,3 +1,3 @@
-SRC_URI = "git://github.com/hyperrealm/libconfig.git"
+SRC_URI = "git://github.com/hyperrealm/libconfig.git;protocol=https"
 SRCREV = "v1.5"
 S = "${WORKDIR}/git"

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-extended/xt-log/xt-log_git.bbappend
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-extended/xt-log/xt-log_git.bbappend
@@ -1,2 +1,2 @@
-SRC_URI = "git://github.com/xen-troops/${PN}.git;branch=master"
+SRC_URI = "git://github.com/xen-troops/${PN}.git;branch=master;protocol=https"
 SRCREV = "a88163b7f64c4eec4f7362ba33ecd55bd3dd1cdb"

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-graphics/wayland/wayland-ivi-extension_1.11.0.bb
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-graphics/wayland/wayland-ivi-extension_1.11.0.bb
@@ -6,7 +6,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=1f1a56bb2dadf5f2be8eb342acf4ed79"
 
 SRCREV = "c9001582b10ce209c37b42dd560947c5aa8928b3"
-SRC_URI = "git://github.com/GENIVI/${BPN}.git;protocol=http \
+SRC_URI = "git://github.com/GENIVI/${BPN}.git;protocol=https \
     "
 S = "${WORKDIR}/git"
 

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-graphics/wayland/wayland-ivi-extension_2.2.0_weston-5.bb
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-graphics/wayland/wayland-ivi-extension_2.2.0_weston-5.bb
@@ -5,7 +5,7 @@ BUGTRACKER = "http://bugs.genivi.org/enter_bug.cgi?product=Wayland%20IVI%20Exten
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=1f1a56bb2dadf5f2be8eb342acf4ed79"
 
-SRC_URI = "git://github.com/GENIVI/${BPN}.git;protocol=http \
+SRC_URI = "git://github.com/GENIVI/${BPN}.git;protocol=https \
     "
 S = "${WORKDIR}/git"
 

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-graphics/wayland/wayland-ivi-extension_2.2.0_weston-5.bbappend
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-graphics/wayland/wayland-ivi-extension_2.2.0_weston-5.bbappend
@@ -1,6 +1,6 @@
 FILESEXTRAPATHS_append := ":${THISDIR}/${PN}"
 
-SRC_URI = "git://github.com/GENIVI/${BPN}.git;protocol=http"
+SRC_URI = "git://github.com/GENIVI/${BPN}.git;protocol=https"
 SRCREV = "2.2.0_weston_5_compartible"
 
 SRC_URI_IVI_ID_AGENT = " \

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux-libc-headers/linux-libc-headers_%.bbappend
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux-libc-headers/linux-libc-headers_%.bbappend
@@ -1,4 +1,4 @@
-RENESAS_BSP_URL = "git://github.com/xen-troops/linux.git"
+RENESAS_BSP_URL = "git://github.com/xen-troops/linux.git;protocol=https"
 
 BRANCH = "v4.14.75-ltsi/rcar-3.9.6-xt0.1"
 SRCREV = "a49b495859d0d379ac4ca2068a5c42c1452df8b3"

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas_%.bbappend
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas_%.bbappend
@@ -2,7 +2,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
 require inc/xt_shared_env.inc
 
-RENESAS_BSP_URL = "git://github.com/xen-troops/linux.git"
+RENESAS_BSP_URL = "git://github.com/xen-troops/linux.git;protocol=https"
 
 BRANCH = "v4.14.75-ltsi/rcar-3.9.6-xt0.1"
 SRCREV = "a49b495859d0d379ac4ca2068a5c42c1452df8b3"

--- a/recipes-domu/domu-image-fusion/files/meta-xt-prod-extra/recipes-kernel/linux/linux-generic-armv8.bbappend
+++ b/recipes-domu/domu-image-fusion/files/meta-xt-prod-extra/recipes-kernel/linux/linux-generic-armv8.bbappend
@@ -7,7 +7,7 @@ SRCREV = "79b42d9fbd28b13d882a8c60b7e89b497662ae96"
 LINUX_VERSION = "4.14.35"
 
 SRC_URI = " \
-    git://github.com/xen-troops/linux.git;branch=${BRANCH} \
+    git://github.com/xen-troops/linux.git;branch=${BRANCH};protocol=https \
     file://defconfig \
   "
 

--- a/recipes-domu/domu-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux-libc-headers/linux-libc-headers_%.bbappend
+++ b/recipes-domu/domu-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux-libc-headers/linux-libc-headers_%.bbappend
@@ -1,4 +1,4 @@
-RENESAS_BSP_URL = "git://github.com/xen-troops/linux.git"
+RENESAS_BSP_URL = "git://github.com/xen-troops/linux.git;protocol=https"
 
 BRANCH = "v4.14.75-ltsi/rcar-3.9.6-xt0.1"
 SRCREV = "a49b495859d0d379ac4ca2068a5c42c1452df8b3"

--- a/recipes-domu/domu-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas_%.bbappend
+++ b/recipes-domu/domu-image-weston/files/meta-xt-prod-extra/recipes-kernel/linux/linux-renesas_%.bbappend
@@ -2,7 +2,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
 require inc/xt_shared_env.inc
 
-RENESAS_BSP_URL = "git://github.com/xen-troops/linux.git"
+RENESAS_BSP_URL = "git://github.com/xen-troops/linux.git;protocol=https"
 
 BRANCH = "v4.14.75-ltsi/rcar-3.9.6-xt0.1"
 SRCREV = "a49b495859d0d379ac4ca2068a5c42c1452df8b3"


### PR DESCRIPTION
Use https instead of git because unauthenticated git protocol is disabled by github.

Signed-off-by: Ihor Usyk <ihor_usyk@epam.com>