### PR TITLE
domd: Wrap VIS related code by XT_USE_VIS_SERVER

### DIFF
--- a/recipes-domd/domd-image-weston/domd-image-weston.bbappend
+++ b/recipes-domd/domd-image-weston/domd-image-weston.bbappend
@@ -5,7 +5,8 @@ python __anonymous () {
     product_name = d.getVar('XT_PRODUCT_NAME', True)
     folder_name = product_name.replace("-", "_")
     d.setVar('XT_MANIFEST_FOLDER', folder_name)
-    if product_name == "prod-devel-src" and not "domu" in d.getVar('XT_GUESTS_BUILD', True).split():
+
+    if d.getVar('XT_USE_VIS_SERVER', True) and not d.getVar("AOS_VIS_PACKAGE_DIR", True):
         d.appendVar("XT_QUIRK_BB_ADD_LAYER", "meta-aos")
 
     if product_name == "prod-devel-src": 
@@ -160,15 +161,23 @@ configure_versions_rcar() {
         base_set_conf_value ${local_conf} DISTRO_FEATURES_remove "ivi-shell"
     fi
 
-    if [ ! -z "${AOS_VIS_PLUGINS}" ];then
-        base_update_conf_value ${local_conf} AOS_VIS_PLUGINS "${AOS_VIS_PLUGINS}"
+    if [ -n "${XT_USE_VIS_SERVER}" ]; then
+        base_set_conf_value ${local_conf} DISTRO_FEATURES_append " vis"
+        if [ ! -z "${AOS_VIS_PLUGINS}" ];then
+            base_update_conf_value ${local_conf} AOS_VIS_PLUGINS "${AOS_VIS_PLUGINS}"
+        fi
+    else
+        # Mask bbappend to avoid warning "No recipes available for"
+        base_add_conf_value ${local_conf} BBMASK "meta-xt-prod-extra/recipes-aos/aos-vis/"
     fi
 
     # Disable shared link for GO packages
     base_set_conf_value ${local_conf} GO_LINKSHARED ""
 
-    if [ ! -z "${AOS_VIS_PACKAGE_DIR}" ];then
-        base_update_conf_value ${local_conf} AOS_VIS_PACKAGE_DIR "${AOS_VIS_PACKAGE_DIR}"
+    if [ -n "${XT_USE_VIS_SERVER}" ]; then
+        if [ ! -z "${AOS_VIS_PACKAGE_DIR}" ];then
+            base_update_conf_value ${local_conf} AOS_VIS_PACKAGE_DIR "${AOS_VIS_PACKAGE_DIR}"
+        fi
     fi
 
     # Only Kingfisher variants have WiFi and bluetooth
@@ -207,6 +216,8 @@ do_install_append () {
     find ${LAYERDIR}/doc -iname "u-boot-env*" -exec cp -f {} ${DEPLOY_DIR}/domd-image-weston/images/${MACHINE}-xt \; || true
     find ${LAYERDIR}/doc -iname "mk_sdcard_image.sh" -exec cp -f {} ${DEPLOY_DIR}/domd-image-weston/images/${MACHINE}-xt \; \
     -exec cp -f {} ${DEPLOY_DIR} \; || true
-    find ${DEPLOY_DIR}/${PN}/ipk/aarch64 -iname "aos-vis_git*" -exec cp -f {} ${DEPLOY_DIR}/domd-image-weston/images/${MACHINE}-xt \; && \
-    find ${DEPLOY_DIR}/domd-image-weston/images/${MACHINE}-xt -iname "aos-vis_git*" -exec ln -sfr {} ${DEPLOY_DIR}/domd-image-weston/images/${MACHINE}-xt/aos-vis \; || true
+    if [ -n "${XT_USE_VIS_SERVER}" ]; then
+        find ${DEPLOY_DIR}/${PN}/ipk/aarch64 -iname "aos-vis_git*" -exec cp -f {} ${DEPLOY_DIR}/domd-image-weston/images/${MACHINE}-xt \; && \
+        find ${DEPLOY_DIR}/domd-image-weston/images/${MACHINE}-xt -iname "aos-vis_git*" -exec ln -sfr {} ${DEPLOY_DIR}/domd-image-weston/images/${MACHINE}-xt/aos-vis \; || true
+    fi
 }

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-core/base-files/base-files_%.bbappend
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-core/base-files/base-files_%.bbappend
@@ -9,7 +9,7 @@ do_install_append () {
 	echo "	shopt -s checkwinsize" >> ${D}${sysconfdir}/profile
 	echo "  resize 1> /dev/null" >> ${D}${sysconfdir}/profile
 	echo "fi" >> ${D}${sysconfdir}/profile
-       if [ ! -z "${AOS_VIS_PLUGINS}" ]; then
+       if ${@bb.utils.contains('DISTRO_FEATURES', 'vis', 'true', 'false', d)}; then
            echo "192.168.0.1 wwwivi" >> ${D}${sysconfdir}/hosts
        fi
 }

--- a/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-graphics/images/core-image-weston.bbappend
+++ b/recipes-domd/domd-image-weston/files/meta-xt-prod-extra/recipes-graphics/images/core-image-weston.bbappend
@@ -15,10 +15,13 @@ IMAGE_INSTALL_append = " \
 "
 
 python __anonymous () {
-    if (d.getVar("AOS_VIS_PACKAGE_DIR", True) or "") == "" and not "domu" in (d.getVar("XT_GUESTS_INSTALL", True).split()):
-        d.appendVar("IMAGE_INSTALL", "aos-vis")
-    if (d.getVar("AOS_VIS_PACKAGE_DIR", True) or "") != "" and not "domu" in (d.getVar("XT_GUESTS_INSTALL", True).split()):
-        d.appendVar("IMAGE_INSTALL", "ca-certificates")
+    if 'vis' in d.getVar('DISTRO_FEATURES', True):
+        if d.getVar("AOS_VIS_PACKAGE_DIR", True):
+            # VIS is from prebuilt binaries
+            d.appendVar("IMAGE_INSTALL", "ca-certificates")
+        else:
+            # VIS is from sources
+            d.appendVar("IMAGE_INSTALL", "aos-vis")
 }
 
 # Configuration for ARM Trusted Firmware
@@ -50,12 +53,11 @@ populate_vmlinux () {
 IMAGE_POSTPROCESS_COMMAND += "populate_vmlinux; "
 
 install_aos () {
-    if echo "${XT_GUESTS_INSTALL}" | grep -qi "domu";then
-        exit 0
-    fi
     if [ ! -z "${AOS_VIS_PACKAGE_DIR}" ];then
         opkg install ${AOS_VIS_PACKAGE_DIR}/aos-vis
     fi
 }
 
-ROOTFS_POSTPROCESS_COMMAND += "install_aos; "
+ROOTFS_POSTPROCESS_COMMAND += " \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'vis', 'install_aos;', '', d)} \
+"


### PR DESCRIPTION
This patch introduces new variable XT_USE_VIS_SERVER.
When this variable is not defined or empty then VIS
components will be not used in build of DomD.

If XT_USE_VIS_SERVER is not empty then VIS components
will be used in build as sources or prebuilt binary,
depending on two other mutually exclusive variables,
already present in sources:
- AOS_VIS_PLUGINS for build from sources;
- AOS_VIS_PACKAGE_DIR for prebuilt binary.

We need to take into account that VIS related manipulations
are performed on two levels: upper and lower (DomD).
On upper level we use variable XT_USE_VIS_SERVER as is.

On lower level (inside build of DomD) we use
DISTRO_FEATURE "vis" as "more natural for Linux"
presentation of XT_USE_VIS_SERVER switch.

Signed-off-by: Ruslan Shymkevych <ruslan_shymkevych@epam.com>
Acked-by: Oleksandr Grytsov <oleksandr_grytsov@epam.com>