### PR TITLE
INSTALL.txt: Fix folder tree for Android prebuilt graphic

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -136,56 +136,57 @@ I.e. you should have such directories structure:
 ├── pvr-km
 │   └── pvrsrvkm.ko
 └── pvr-um
-    ├── prebuilds.mk
-    └── vendor
-        ├── bin
-        │   ├── hwperfbin2jsont
-        │   ├── pvrhwperf
-        │   ├── pvrlogdump
-        │   ├── pvrlogsplit
-        │   ├── pvrsrvctl
-        │   └── rscompiler
-        ├── etc
-        │   ├── firmware
-        │   │   ├── rgx.fw.4.46.6.62
-        │   │   └── rgx.fw.4.46.6.62.vz
-        │   └── powervr.ini
-        ├── lib
-        │   ├── egl
-        │   │   ├── libEGL_POWERVR_ROGUE.so
-        │   │   ├── libGLESv1_CM_POWERVR_ROGUE.so
-        │   │   └── libGLESv2_POWERVR_ROGUE.so
-        │   ├── hw
-        │   │   ├── gralloc.r8a7795.so
-        │   │   ├── memtrack.r8a7795.so
-        │   │   └── vulkan.r8a7795.so
-        │   ├── libAppHintsIPC.so
-        │   ├── libglslcompiler.so
-        │   ├── libIMGegl.so
-        │   ├── libPVRRS.so
-        │   ├── libPVRScopeServices.so
-        │   ├── libsrv_um.so
-        │   ├── libufwriter.so
-        │   ├── libusc.so
-        │   └── vendor.imagination.gpu.apphints@1.0.so
-        └── lib64
-            ├── egl
-            │   ├── libEGL_POWERVR_ROGUE.so
-            │   ├── libGLESv1_CM_POWERVR_ROGUE.so
-            │   └── libGLESv2_POWERVR_ROGUE.so
-            ├── hw
-            │   ├── gralloc.r8a7795.so
-            │   ├── memtrack.r8a7795.so
-            │   └── vulkan.r8a7795.so
-            ├── libAppHintsIPC.so
-            ├── libglslcompiler.so
-            ├── libIMGegl.so
-            ├── libPVRRS.so
-            ├── libPVRScopeServices.so
-            ├── libsrv_um.so
-            ├── libufwriter.so
-            ├── libusc.so
-            └── vendor.imagination.gpu.apphints@1.0.so
+    └── <r8a7795 or r8a7796>
+        ├── prebuilds.mk
+        └── vendor
+            ├── bin
+            │   ├── hwperfbin2jsont
+            │   ├── pvrhwperf
+            │   ├── pvrlogdump
+            │   ├── pvrlogsplit
+            │   ├── pvrsrvctl
+            │   └── rscompiler
+            ├── etc
+            │   ├── firmware
+            │   │   ├── rgx.fw.4.46.6.62
+            │   │   └── rgx.fw.4.46.6.62.vz
+            │   └── powervr.ini
+            ├── lib
+            │   ├── egl
+            │   │   ├── libEGL_POWERVR_ROGUE.so
+            │   │   ├── libGLESv1_CM_POWERVR_ROGUE.so
+            │   │   └── libGLESv2_POWERVR_ROGUE.so
+            │   ├── hw
+            │   │   ├── gralloc.r8a7795.so
+            │   │   ├── memtrack.r8a7795.so
+            │   │   └── vulkan.r8a7795.so
+            │   ├── libAppHintsIPC.so
+            │   ├── libglslcompiler.so
+            │   ├── libIMGegl.so
+            │   ├── libPVRRS.so
+            │   ├── libPVRScopeServices.so
+            │   ├── libsrv_um.so
+            │   ├── libufwriter.so
+            │   ├── libusc.so
+            │   └── vendor.imagination.gpu.apphints@1.0.so
+            └── lib64
+                ├── egl
+                │   ├── libEGL_POWERVR_ROGUE.so
+                │   ├── libGLESv1_CM_POWERVR_ROGUE.so
+                │   └── libGLESv2_POWERVR_ROGUE.so
+                ├── hw
+                │   ├── gralloc.r8a7795.so
+                │   ├── memtrack.r8a7795.so
+                │   └── vulkan.r8a7795.so
+                ├── libAppHintsIPC.so
+                ├── libglslcompiler.so
+                ├── libIMGegl.so
+                ├── libPVRRS.so
+                ├── libPVRScopeServices.so
+                ├── libsrv_um.so
+                ├── libufwriter.so
+                ├── libusc.so
+                └── vendor.imagination.gpu.apphints@1.0.so
 
 
 XT_ANDROID_PREBUILDS_DIR should point to "..ANDROID_PREBUILTS_FOLDER_PATH.." folder.


### PR DESCRIPTION
Add `<r8a7795 or r8a7796>` under `pvr-um`.
See corresponding change in `android_device_xenvm`.